### PR TITLE
upgrading html-to-markdown to 1.3.0

### DIFF
--- a/packages/writr-cli/package.json
+++ b/packages/writr-cli/package.json
@@ -51,7 +51,7 @@
     "keyv": "^4.5.2",
     "luxon": "^3.1.0",
     "moment": "^2.29.4",
-    "node-html-markdown": "^1.2.2",
+    "node-html-markdown": "^1.3.0",
     "parse-json": "^6.0.2",
     "striptags": "^3.2.0",
     "winston": "^3.8.2"


### PR DESCRIPTION
upgrading html-to-markdown to 1.3.0