### PR TITLE
Fix front matter parsing for Windows line endings

### DIFF
--- a/src/writr.ts
+++ b/src/writr.ts
@@ -163,14 +163,12 @@ export class Writr extends Hookified {
 			return '';
 		}
 
-		const start = this._content.indexOf('---\n');
+		const match = /^\s*(---\r?\n[\s\S]*?\r?\n---(?:\r?\n|$))/.exec(this._content);
+		if (match) {
+			return match[1];
+		}
 
-		const end = this._content.indexOf('\n---\n', start + 4);
-		if (end === -1) {
-			return '';
-		} // Return empty string if no ending delimiter is found
-
-		return this._content.slice(start, end + 5); // Extract front matter including delimiters
+		return '';
 	}
 
 	/**
@@ -178,15 +176,14 @@ export class Writr extends Hookified {
 	 * @type {string} The markdown content without the front matter.
 	 */
 	public get body(): string {
-		// Is there front matter content?
-		if (this.frontMatterRaw === '') {
+		const frontMatter = this.frontMatterRaw;
+		if (frontMatter === '') {
 			return this._content;
 		}
 
-		const end = this._content.indexOf('\n---\n');
-
-		// Return the content after the closing --- marker
-		return this._content.slice(Math.max(0, end + 5)).trim();
+		return this._content
+			.slice(this._content.indexOf(frontMatter) + frontMatter.length)
+			.trim();
 	}
 
 	/**

--- a/test/writr.test.ts
+++ b/test/writr.test.ts
@@ -349,6 +349,18 @@ describe('WritrFrontMatter', () => {
 		const writr = new Writr(markdownWithFrontMatterInOtherPlaces as string);
 		expect(writr.body).to.contain('---');
 	});
+	test('should handle windows style line endings in front matter', () => {
+		const markdown = '---\r\nfoo: bar\r\n---\r\n\r\n# Heading';
+		const writr = new Writr(markdown);
+		expect(writr.frontMatterRaw).toBe('---\r\nfoo: bar\r\n---\r\n');
+		expect(writr.body).toBe('# Heading');
+	});
+	test('should handle front matter without trailing newline', () => {
+		const markdown = '---\nfoo: bar\n---';
+		const writr = new Writr(markdown);
+		expect(writr.frontMatterRaw).toBe('---\nfoo: bar\n---');
+		expect(writr.body).toBe('');
+	});
 	test('if frontMatter is not correct yaml it should emit an error and return {}', () => {
 		const writr = new Writr(markdownWithBadFrontMatter as string);
 		expect(writr.frontMatter).toStrictEqual({});


### PR DESCRIPTION
## Summary
- handle Windows-style CRLF line endings when extracting front matter
- support front matter blocks missing a trailing newline
- add tests for CRLF front matter and EOF front matter

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689fb951fd44832494d4405332f54cea