### PR TITLE
feat: speed up validation

### DIFF
--- a/src/writr.ts
+++ b/src/writr.ts
@@ -361,11 +361,17 @@ export class Writr extends Hookified {
 				this._content = content;
 			}
 
-			// Ensure caching is disabled for validation
-			const validationOptions = options
-				? { ...options, caching: false }
-				: undefined;
-			await this.render(validationOptions);
+			let { engine } = this;
+			if (options) {
+				options = {
+					...this._options.renderOptions,
+					...options,
+					caching: false,
+				};
+				engine = this.createProcessor(options);
+			}
+
+			await engine.run(engine.parse(this.body));
 
 			if (content !== undefined) {
 				this._content = originalContent;
@@ -396,11 +402,17 @@ export class Writr extends Hookified {
 				this._content = content;
 			}
 
-			// Ensure caching is disabled for validation
-			const validationOptions = options
-				? { ...options, caching: false }
-				: undefined;
-			this.renderSync(validationOptions);
+			let { engine } = this;
+			if (options) {
+				options = {
+					...this._options.renderOptions,
+					...options,
+					caching: false,
+				};
+				engine = this.createProcessor(options);
+			}
+
+			engine.runSync(engine.parse(this.body));
 
 			if (content !== undefined) {
 				this._content = originalContent;


### PR DESCRIPTION
## Summary
- avoid full rendering in `validate` and `validateSync` by parsing and running the processor only
- keep caching disabled while honoring custom render options

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68c349c600dc832483a0106b1dd59479