### PR TITLE
fix: unify default engine with createProcessor for consistent blockquote rendering

### DIFF
--- a/src/writr.ts
+++ b/src/writr.ts
@@ -48,17 +48,8 @@ import { WritrHooks } from "./types.js";
 import { WritrAI } from "./writr-ai.js";
 
 export class Writr extends Hookified {
-	public engine = unified()
-		.use(remarkParse)
-		.use(remarkGfm) // Use GitHub Flavored Markdown
-		.use(remarkToc) // Add table of contents
-		.use(remarkEmoji) // Add emoji support
-		.use(remarkRehype) // Convert markdown to HTML
-		.use(rehypeSlug) // Add slugs to headings in HTML
-		.use(remarkMath) // Add math support
-		.use(rehypeKatex) // Add math support
-		.use(rehypeHighlight) // Apply syntax highlighting
-		.use(rehypeStringify); // Stringify HTML
+	// biome-ignore lint/suspicious/noExplicitAny: expected unified processor
+	public engine: any;
 
 	private readonly _options: WritrOptions = {
 		renderOptions: {
@@ -103,19 +94,13 @@ export class Writr extends Hookified {
 			this._content = arguments1;
 		} else if (arguments1) {
 			this._options = this.mergeOptions(this._options, arguments1);
-			/* v8 ignore next -- @preserve */
-			if (this._options.renderOptions) {
-				this.engine = this.createProcessor(this._options.renderOptions);
-			}
 		}
 
 		if (arguments2) {
 			this._options = this.mergeOptions(this._options, arguments2);
-			/* v8 ignore next -- @preserve */
-			if (this._options.renderOptions) {
-				this.engine = this.createProcessor(this._options.renderOptions);
-			}
 		}
+
+		this.engine = this.createProcessor(this._options.renderOptions ?? {});
 
 		if (this._options.ai) {
 			this._ai = new WritrAI(this, this._options.ai);
@@ -651,7 +636,7 @@ export class Writr extends Hookified {
 		}
 
 		if (options.toc) {
-			processor.use(remarkToc, { heading: "toc|table of contents" });
+			processor.use(remarkToc);
 		}
 
 		if (options.emoji) {
@@ -660,6 +645,10 @@ export class Writr extends Hookified {
 
 		if (options.mdx) {
 			processor.use(remarkMDX);
+		}
+
+		if (options.math) {
+			processor.use(remarkMath);
 		}
 
 		// biome-ignore lint/suspicious/noExplicitAny: remarkRehype handler types
@@ -691,7 +680,7 @@ export class Writr extends Hookified {
 		}
 
 		if (options.math) {
-			processor.use(remarkMath).use(rehypeKatex);
+			processor.use(rehypeKatex);
 		}
 
 		processor.use(rehypeStringify);

--- a/src/writr.ts
+++ b/src/writr.ts
@@ -17,7 +17,7 @@ import remarkMDX from "remark-mdx";
 import remarkParse from "remark-parse";
 import remarkRehype from "remark-rehype";
 import remarkToc from "remark-toc";
-import { unified } from "unified";
+import { type Processor, unified } from "unified";
 import { WritrCache } from "./writr-cache.js";
 
 export type {
@@ -48,8 +48,8 @@ import { WritrHooks } from "./types.js";
 import { WritrAI } from "./writr-ai.js";
 
 export class Writr extends Hookified {
-	// biome-ignore lint/suspicious/noExplicitAny: expected unified processor
-	public engine: any;
+	// biome-ignore lint/suspicious/noExplicitAny: plugin chaining changes generic type params
+	public engine: Processor<any, any, any, any, any>;
 
 	private readonly _options: WritrOptions = {
 		renderOptions: {
@@ -626,8 +626,10 @@ export class Writr extends Hookified {
 		return this._options?.renderOptions?.caching ?? false;
 	}
 
-	// biome-ignore lint/suspicious/noExplicitAny: expected unified processor
-	private createProcessor(options: RenderOptions): any {
+	private createProcessor(
+		options: RenderOptions,
+		// biome-ignore lint/suspicious/noExplicitAny: plugin chaining changes generic type params
+	): Processor<any, any, any, any, any> {
 		const processor = unified().use(remarkParse);
 
 		if (options.gfm) {

--- a/test/writr.test.ts
+++ b/test/writr.test.ts
@@ -140,6 +140,38 @@ describe("writr", () => {
 		expect(result).toContain("NOTE");
 		expect(result).toContain("This is a note alert with useful information.");
 	});
+	it("should render lists inside blockquotes correctly", async () => {
+		const md =
+			"> 🚧 At this time Hyphen Deploy supports containerized applications running on:\n>\n> - 🚧 Amazon Elastic Container Service (ECS)\n> - 🚧 Azure Container Apps\n> - 🚧 Google Cloudrun";
+		const writr = new Writr(md);
+		const result = await writr.render();
+		expect(result).toContain("<blockquote>");
+		expect(result).toContain("<ul>");
+		expect(result).toContain(
+			"<li>🚧 Amazon Elastic Container Service (ECS)</li>",
+		);
+		expect(result).toContain("<li>🚧 Azure Container Apps</li>");
+		expect(result).toContain("<li>🚧 Google Cloudrun</li>");
+	});
+	it("should render lists inside blockquotes without blank separator line", async () => {
+		const md = "> Text:\n> - item1\n> - item2\n> - item3";
+		const writr = new Writr(md);
+		const result = await writr.render();
+		expect(result).toContain("<blockquote>");
+		expect(result).toContain("<ul>");
+		expect(result).toContain("<li>item1</li>");
+		expect(result).toContain("<li>item2</li>");
+		expect(result).toContain("<li>item3</li>");
+	});
+	it("should render lists inside blockquotes with renderSync", () => {
+		const md = "> Text:\n>\n> - item1\n> - item2";
+		const writr = new Writr(md);
+		const result = writr.renderSync();
+		expect(result).toContain("<blockquote>");
+		expect(result).toContain("<ul>");
+		expect(result).toContain("<li>item1</li>");
+		expect(result).toContain("<li>item2</li>");
+	});
 	it("should not render GitHub blockquote alerts when gfm is disabled", async () => {
 		const writr = new Writr(
 			"> [!NOTE]\n> This is a note alert with useful information.",


### PR DESCRIPTION
## Summary

- **Unifies the default engine with `createProcessor`** — the static default engine (line 51) was hand-coded and inconsistent with `createProcessor`, missing `remarkGithubBlockquoteAlert` and having `remarkMath` in the wrong plugin phase (after `remarkRehype` instead of before). The constructor now always uses `createProcessor` to build the engine.
- **Fixes `remarkMath` plugin ordering** — `remarkMath` is a remark plugin (mdast phase) but was placed after `remarkRehype` (the bridge to hast). It's now correctly placed before `remarkRehype`, with `rehypeKatex` remaining in the rehype phase.
- **Adds test coverage for blockquote + list rendering** — three new tests covering the exact scenario from issue #443 (lists inside blockquotes with emoji), lists without blank separator lines, and sync rendering.

Closes #443

## Test plan

- [x] All 176 existing tests pass
- [x] 3 new blockquote + list tests pass
- [x] `pnpm build` succeeds
- [x] `pnpm test` passes with 100% statement/function/line coverage

https://claude.ai/code/session_01EtCwTREZoVsyLxnPKp6Fzu