### PR TITLE
ci: upgrade to pnpm 11 (pnpm/action-setup) and Node 22/24/26

### DIFF
--- a/.github/workflows/ai-integration-tests.yml
+++ b/.github/workflows/ai-integration-tests.yml
@@ -21,13 +21,16 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - name: Install pnpm
+      uses: pnpm/action-setup@v4
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
+        cache: 'pnpm'
 
     - name: Install Dependencies
-      run: npm install -g pnpm && pnpm install
+      run: pnpm install
 
     - name: Build
       run: pnpm build

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -17,13 +17,16 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - name: Install pnpm
+      uses: pnpm/action-setup@v4
     - name: Use Node.js
       uses: actions/setup-node@v4
       with:
         node-version: 24
+        cache: 'pnpm'
 
     - name: Install Dependencies
-      run: npm install -g pnpm && pnpm install
+      run: pnpm install
 
     - name: Build    
       run: pnpm build

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -18,13 +18,17 @@ jobs:
       uses: actions/checkout@v4
 
     # Test
+    - name: Install pnpm
+      uses: pnpm/action-setup@v4
+
     - name: Use Node.js
       uses: actions/setup-node@v4
       with:
         node-version: 24
+        cache: 'pnpm'
 
-    - name: Install Dependencies  
-      run: npm install -g pnpm && pnpm install
+    - name: Install Dependencies
+      run: pnpm install
       
     - name: Build
       run: pnpm build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,13 +16,16 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - name: Install pnpm
+      uses: pnpm/action-setup@v4
     - name: Use Node.js
       uses: actions/setup-node@v4
       with:
         node-version: 24
+        cache: 'pnpm'
 
     - name: Install Dependencies
-      run: npm install -g pnpm && pnpm install
+      run: pnpm install
 
     - name: Build    
       run: pnpm build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,17 +17,20 @@ jobs:
 
     strategy:
       matrix:
-        node-version: ['20', '22', '24']
+        node-version: ['22', '24', '26']
 
     steps:
     - uses: actions/checkout@v4
+    - name: Install pnpm
+      uses: pnpm/action-setup@v4
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
+        cache: 'pnpm'
 
     - name: Install Dependencies
-      run: npm install -g pnpm && pnpm install
+      run: pnpm install
 
     - name: Build
       run: pnpm build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ Writr is a Node.js markdown rendering library built with TypeScript. It simplifi
 3. **Follow existing code style** - Biome enforces formatting and linting
 4. **Mirror source structure in tests** - Test files go in `test/` matching `src/` structure
 5. **Maintain ESM-only compatibility** - This is an ESM-only package
-6. **Test on Node.js >= 20** - Minimum supported version is Node 20
+6. **Test on Node.js >= 22** - Minimum supported version is Node 22
 
 ## Structure
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "6.1.2",
   "description": "Markdown Rendering Simplified",
   "type": "module",
+  "packageManager": "pnpm@11.6.0",
   "main": "./dist/writr.mjs",
   "types": "./dist/writr.d.mts",
   "exports": {
@@ -17,7 +18,7 @@
   },
   "author": "Jared Wray <me@jaredwray.com>",
   "engines": {
-    "node": ">=20"
+    "node": "^22.18.0"
   },
   "license": "MIT",
   "keywords": [

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,4 @@
 minimumReleaseAge: 2880
-onlyBuiltDependencies:
-  - esbuild
-  - unrs-resolver
+allowBuilds:
+  esbuild: true
+  unrs-resolver: true


### PR DESCRIPTION
## Summary

Tooling-only upgrade — **no npm dependency version bumps**. This PR is scoped to the pnpm/CI toolchain; application dependency upgrades will follow in separate grouped PRs.

## Changes

- **pnpm 11**: pin `pnpm@11.6.0` via the `packageManager` field.
- **GitHub Actions**: replace `npm install -g pnpm && pnpm install` with `pnpm/action-setup@v4` and enable `cache: 'pnpm'` in `setup-node` across all five workflows (tests, code-coverage, ai-integration-tests, deploy-site, release).
- **Build-script approval**: pnpm 11 uses the new `allowBuilds` map instead of `onlyBuiltDependencies`; added `allowBuilds` (`esbuild`, `unrs-resolver`) and dropped the deprecated key. Without this, `pnpm install` fails with `ERR_PNPM_IGNORED_BUILDS`.
- **Node**: test matrix → `22, 24, 26` (drop Node 20); `engines.node` → `^22.18.0`; AGENTS.md minimum → Node 22.

## Verification

- `pnpm install` + `pnpm build` + `pnpm test:ci` pass on pnpm 11.6.0 (186 tests, 100% coverage).
- The lockfile is **unchanged** from `main` — this PR adds no dependency upgrades.

https://claude.ai/code/session_0182vBDgYSUFPGmnhTFqLH5N