### PR TITLE
root - chore: upgrade html-react-parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "cacheable": "^2.3.5",
     "hashery": "^2.0.0",
     "hookified": "^2.1.0",
-    "html-react-parser": "^6.0.1",
+    "html-react-parser": "^6.1.3",
     "js-yaml": "^4.1.1",
     "react": "^19.2.7",
     "rehype-highlight": "^7.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^2.1.0
         version: 2.1.1
       html-react-parser:
-        specifier: ^6.0.1
-        version: 6.0.1(@types/react@19.2.17)(react@19.2.7)
+        specifier: ^6.1.3
+        version: 6.1.3(@types/react@19.2.17)(react@19.2.7)
       js-yaml:
         specifier: ^4.1.1
         version: 4.1.1
@@ -1362,11 +1362,23 @@ packages:
   html-dom-parser@7.0.1:
     resolution: {integrity: sha512-loRBDTCY/05/jAC63J1X9ID+xjRucmpLkIcQO0IRbOubBo5ucnpUpyXXob9UMXOskMZlu7KPsDP/2KOMelzJNA==}
 
+  html-dom-parser@8.0.0:
+    resolution: {integrity: sha512-cWLJ8mt930VceOzVfY/J+T1ou9v3ENT0BgWqy5aEZjdFp37TYLXULjX8u0vD2rBpFAkK5IofOPl0y4Gq0QLIyA==}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   html-react-parser@6.0.1:
     resolution: {integrity: sha512-tIie2HSIk2Ct1tdupjd/DhBjskxN/NL5J4ncbUnk2smBr5UIfpPpitUo0imGfBM0BlOL7ac8RcqEwne1jXTcsQ==}
+    peerDependencies:
+      '@types/react': 0.14 || 15 || 16 || 17 || 18 || 19
+      react: 0.14 || 15 || 16 || 17 || 18 || 19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  html-react-parser@6.1.3:
+    resolution: {integrity: sha512-CTsKtLJA23cgTbcJYT8vgHAPSqGY7NM+/mv+Tv6I0DqkLCa3FlceK2htH8AwlGa03BopqnVvK/XHqQq7HAw/sg==}
     peerDependencies:
       '@types/react': 0.14 || 15 || 16 || 17 || 18 || 19
       react: 0.14 || 15 || 16 || 17 || 18 || 19
@@ -2153,6 +2165,9 @@ packages:
 
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
+
+  style-to-js@2.0.0:
+    resolution: {integrity: sha512-amkl/SwHF/Gb430+eOiN+XToZ6VsD2nota1kCXps4k1xagZOniEVNm8zKYm7RrGm2Q6d6hjnZdqebFIunoSJng==}
 
   style-to-object@1.0.14:
     resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
@@ -3581,6 +3596,11 @@ snapshots:
       domhandler: 6.0.1
       htmlparser2: 12.0.0
 
+  html-dom-parser@8.0.0:
+    dependencies:
+      domhandler: 6.0.1
+      htmlparser2: 12.0.0
+
   html-escaper@2.0.2: {}
 
   html-react-parser@6.0.1(@types/react@19.2.17)(react@19.2.5):
@@ -3593,13 +3613,13 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
-  html-react-parser@6.0.1(@types/react@19.2.17)(react@19.2.7):
+  html-react-parser@6.1.3(@types/react@19.2.17)(react@19.2.7):
     dependencies:
       domhandler: 6.0.1
-      html-dom-parser: 7.0.1
+      html-dom-parser: 8.0.0
       react: 19.2.7
       react-property: 2.0.2
-      style-to-js: 1.1.21
+      style-to-js: 2.0.0
     optionalDependencies:
       '@types/react': 19.2.17
 
@@ -4744,6 +4764,10 @@ snapshots:
   stubborn-utils@1.0.2: {}
 
   style-to-js@1.1.21:
+    dependencies:
+      style-to-object: 1.0.14
+
+  style-to-js@2.0.0:
     dependencies:
       style-to-object: 1.0.14
 


### PR DESCRIPTION
## Summary
Upgrade `html-react-parser` (used to render HTML output as React elements).

## Versions
- `html-react-parser` `6.0.1` → `6.1.3`

## Tests
- [x] `pnpm build` passes
- [x] `pnpm test` passes (186 tests, 100% coverage)


---
_Generated by [Claude Code](https://claude.ai/code/session_01BXZCCU6YqZwutPmDRPtYKV)_