### PR TITLE
root - chore: upgrade js-yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "hashery": "^2.0.0",
     "hookified": "^2.1.0",
     "html-react-parser": "^6.1.3",
-    "js-yaml": "^4.1.1",
+    "js-yaml": "^4.2.0",
     "react": "^19.2.7",
     "rehype-highlight": "^7.0.2",
     "rehype-katex": "^7.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^6.1.3
         version: 6.1.3(@types/react@19.2.17)(react@19.2.7)
       js-yaml:
-        specifier: ^4.1.1
-        version: 4.1.1
+        specifier: ^4.2.0
+        version: 4.2.0
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -1493,6 +1493,10 @@ packages:
 
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    hasBin: true
+
+  js-yaml@4.2.0:
+    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -3710,6 +3714,10 @@ snapshots:
   js-tokens@10.0.0: {}
 
   js-yaml@4.1.1:
+    dependencies:
+      argparse: 2.0.1
+
+  js-yaml@4.2.0:
     dependencies:
       argparse: 2.0.1
 


### PR DESCRIPTION
## Summary
Upgrade `js-yaml` (frontmatter parsing).

## Versions
- `js-yaml` `4.1.1` → `4.2.0`

## Tests
- [x] `pnpm build` passes
- [x] `pnpm test` passes (186 tests, 100% coverage)


---
_Generated by [Claude Code](https://claude.ai/code/session_01BXZCCU6YqZwutPmDRPtYKV)_