### PR TITLE
root - chore: upgrade hashery (breaking)

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   "dependencies": {
     "ai": "^6.0.203",
     "cacheable": "^2.3.5",
-    "hashery": "^2.0.0",
+    "hashery": "^3.0.0",
     "hookified": "^2.1.0",
     "html-react-parser": "^6.1.3",
     "js-yaml": "^4.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^2.3.5
         version: 2.3.5
       hashery:
-        specifier: ^2.0.0
-        version: 2.0.0
+        specifier: ^3.0.0
+        version: 3.0.0
       hookified:
         specifier: ^2.1.0
         version: 2.1.1
@@ -1297,6 +1297,10 @@ packages:
     resolution: {integrity: sha512-8kX1QsPocnhTYE55qUE5bOjyOrxctnj+vp5Fx1k46MEtlGNENb0Q1t6ETD/xODQbH5dvzYN8dfwgXglKmRM7CA==}
     engines: {node: '>=20'}
 
+  hashery@3.0.0:
+    resolution: {integrity: sha512-0Qf1UYWmzQ7IgJbciYmxfbH3TXGR8CJQx7syxue+XptHPXYiEO1lmkYQen2PBWLikgei0kwylMZHoUmP8G96lg==}
+    engines: {node: '>=22.18'}
+
   hasown@2.0.3:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
@@ -1358,6 +1362,10 @@ packages:
 
   hookified@2.2.0:
     resolution: {integrity: sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==}
+
+  hookified@3.0.0:
+    resolution: {integrity: sha512-x+jzDjd9CWxdgl6u/K4pjnvw7PZx6ZSpiPGAV43uXlJiJy7r2jIEUxxU1Cv7+rwy1GK5Qt5S+Jp7n81DpcUvTA==}
+    engines: {node: '>=22.18.0'}
 
   html-dom-parser@7.0.1:
     resolution: {integrity: sha512-loRBDTCY/05/jAC63J1X9ID+xjRucmpLkIcQO0IRbOubBo5ucnpUpyXXob9UMXOskMZlu7KPsDP/2KOMelzJNA==}
@@ -3496,7 +3504,11 @@ snapshots:
 
   hashery@2.0.0:
     dependencies:
-      hookified: 2.1.1
+      hookified: 2.2.0
+
+  hashery@3.0.0:
+    dependencies:
+      hookified: 3.0.0
 
   hasown@2.0.3:
     dependencies:
@@ -3619,6 +3631,8 @@ snapshots:
   hookified@2.1.1: {}
 
   hookified@2.2.0: {}
+
+  hookified@3.0.0: {}
 
   html-dom-parser@7.0.1:
     dependencies:


### PR DESCRIPTION
## Summary
Upgrade `hashery` (used for cache-key hashing in `writr-cache` and `writr-ai-cache`) to v3 — a major release.

## Versions
- `hashery` `2.0.0` → `3.0.0`

## Breaking notes
hashery v3 has **no public API changes** — the `Hashery` class and `toHashSync`/`toHash` methods are unchanged, and `Hashery` still extends `Hookified`. writr uses only `new Hashery()` + `toHashSync()`, so no code changes were required. The breaking change is the Node engine bump to `>=22.18`, which writr already requires (`^22.18.0`). Internally, hashery v3 bumps its own `hookified` dependency to 3.0.0.

## Tests
- [x] `pnpm build` passes
- [x] `pnpm test` passes (186 tests, 100% coverage)


---
_Generated by [Claude Code](https://claude.ai/code/session_01BXZCCU6YqZwutPmDRPtYKV)_