### PR TITLE
root - chore: upgrade hookified (breaking)

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "ai": "^6.0.203",
     "cacheable": "^2.3.5",
     "hashery": "^3.0.0",
-    "hookified": "^2.1.0",
+    "hookified": "^3.0.0",
     "html-react-parser": "^6.1.3",
     "js-yaml": "^4.2.0",
     "react": "^19.2.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       hookified:
-        specifier: ^2.1.0
-        version: 2.1.1
+        specifier: ^3.0.0
+        version: 3.0.0
       html-react-parser:
         specifier: ^6.1.3
         version: 6.1.3(@types/react@19.2.17)(react@19.2.7)
@@ -1356,9 +1356,6 @@ packages:
 
   hookified@1.15.1:
     resolution: {integrity: sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==}
-
-  hookified@2.1.1:
-    resolution: {integrity: sha512-AHb76R16GB5EsPBE2J7Ko5kiEyXwviB9P5SMrAKcuAu4vJPZttViAbj9+tZeaQE5zjDme+1vcHP78Yj/WoAveA==}
 
   hookified@2.2.0:
     resolution: {integrity: sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==}
@@ -3627,8 +3624,6 @@ snapshots:
   hookable@6.1.1: {}
 
   hookified@1.15.1: {}
-
-  hookified@2.1.1: {}
 
   hookified@2.2.0: {}
 


### PR DESCRIPTION
## Summary
Upgrade `hookified` (the hook/event base class that `Writr` extends) to v3 — a major release. This also resolves the dedup point raised on #465.

## Versions
- `hookified` `2.1.1` → `3.0.0`

## Breaking notes
hookified v3 has **no public API changes** — the `Hookified` class, its constructor, the `HookifiedOptions` type, and the `hook`/`emit`/`on` methods are unchanged. `Writr extends Hookified` and uses `super({...})`, `this.emit(...)`, `this.hook(...)`, and the `HookifiedOptions` type, so no code changes were required. The breaking change is the Node engine bump to `>=22.18`, which writr already requires (`^22.18.0`).

With this, writr's direct `hookified` matches the `hookified@3` used internally by `hashery@3` (deduplicated). Remaining `hookified@1.x`/`2.x` copies in the tree are deep transitive deps of unrelated packages.

## Tests
- [x] `pnpm build` passes
- [x] `pnpm test` passes (186 tests, 100% coverage)


---
_Generated by [Claude Code](https://claude.ai/code/session_01BXZCCU6YqZwutPmDRPtYKV)_