### PR TITLE
chore: add npm homepage and bugs metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,10 @@
     "type": "git",
     "url": "https://github.com/jaredwray/writr.git"
   },
+  "homepage": "https://github.com/jaredwray/writr#readme",
+  "bugs": {
+    "url": "https://github.com/jaredwray/writr/issues"
+  },
   "author": "Jared Wray <me@jaredwray.com>",
   "engines": {
     "node": "^22.18.0"


### PR DESCRIPTION
## Summary

- add the standard npm `homepage` metadata pointing to the repository README
- add `bugs.url` so registry clients can link directly to the issue tracker
- keep the change metadata-only with no runtime or dependency changes

Closes #470

## Validation

- `pnpm build`
- `pnpm test` (186 tests passed; 100% statement and line coverage)
- `pnpm pack --dry-run --json`
- direct Node assertions for both metadata values
- `git diff --check`

## Environment note

Validation used Node 24.14.0 with the build targeting the package-configured Node 22.18.0 baseline. pnpm emitted the expected engine warning because the manifest currently uses the exact `^22.18.0` range.