### PR TITLE
root - chore: upgrade GitHub Actions (breaking)

### DIFF
--- a/.github/workflows/ai-integration-tests.yml
+++ b/.github/workflows/ai-integration-tests.yml
@@ -20,11 +20,11 @@ jobs:
         node-version: ['24']
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Install pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@v6
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v7
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'pnpm'

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -16,11 +16,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Install pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@v6
     - name: Use Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v7
       with:
         node-version: 24
         cache: 'pnpm'
@@ -35,7 +35,7 @@ jobs:
       run: pnpm test:ci
 
     - name: Code Coverage
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v7
       with:
         token: ${{ secrets.CODECOV_KEY }}
         files: coverage/lcov.info

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -57,7 +57,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -15,14 +15,14 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
 
     # Test
     - name: Install pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@v6
 
     - name: Use Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v7
       with:
         node-version: 24
         cache: 'pnpm'
@@ -39,7 +39,7 @@ jobs:
         ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 
     - name: Publish to Cloudflare Pages
-      uses: cloudflare/wrangler-action@v3
+      uses: cloudflare/wrangler-action@v4
       with:
         apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         command: pages deploy site/dist --project-name=writr-org --branch=main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,11 +15,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Install pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@v6
     - name: Use Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v7
       with:
         node-version: 24
         registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,11 +20,11 @@ jobs:
         node-version: ['22', '24', '26']
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Install pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@v6
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v7
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'pnpm'


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [ ] Tests for the changes have been added — N/A (CI-config-only change; no source or tests affected).

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Chore / CI maintenance — **breaking** (several GitHub Action majors changed). Upgrades every active `uses:` reference in `.github/workflows/` to its latest major version.

## Versions
- `actions/checkout` `v4` → `v7`
- `actions/setup-node` `v4` → `v7`
- `pnpm/action-setup` `v4` → `v6`
- `codecov/codecov-action` `v5` → `v7`
- `cloudflare/wrangler-action` `v3` → `v4`
- `github/codeql-action` stays `@v4` (already the latest major; the pinned tag floats to v4.37.x)

## Verification coverage
- **Exercised by this PR's CI:** `actions/checkout`, `actions/setup-node`, `pnpm/action-setup` (via `tests.yml`, Node 22/24/26), `codecov/codecov-action` (via `code-coverage.yml`), and `github/codeql-action` (via `codeql.yml`). A green run validates these at their new majors.
- **Not exercised by PR CI:** `release.yml` and `deploy-site.yml` only run on release/deploy events, so `cloudflare/wrangler-action` `v3 → v4` (docs-site deploy) is **not** validated here — flagging it for review since wrangler 3→4 is a major CLI change.

## Checks
- [x] All six workflow files parse
- [x] `@vMAJOR` float pin style preserved; `codeql-action@v4` and the commented `actions/setup-example` placeholder left untouched

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bx1tkmgsxoZ7DqJKQGn1hU)_