### PR TITLE
root - chore: upgrade cacheable

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   },
   "dependencies": {
     "ai": "^6.0.203",
-    "cacheable": "^2.3.5",
+    "cacheable": "^2.5.0",
     "hashery": "^3.0.0",
     "hookified": "^3.0.0",
     "html-react-parser": "^6.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^6.0.203
         version: 6.0.203(zod@4.4.3)
       cacheable:
-        specifier: ^2.3.5
-        version: 2.3.5
+        specifier: ^2.5.0
+        version: 2.5.0
       hashery:
         specifier: ^3.0.0
         version: 3.0.0
@@ -250,17 +250,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@cacheable/memory@2.0.8':
-    resolution: {integrity: sha512-FvEb29x5wVwu/Kf93IWwsOOEuhHh6dYCJF3vcKLzXc0KXIW181AOzv6ceT4ZpBHDvAfG60eqb+ekmrnLHIy+jw==}
-
   '@cacheable/memory@2.2.0':
     resolution: {integrity: sha512-CTLKqLItRCEixEAewD3/j9DB3/o96gpTPD4eJ1v+DGOlxZRZncRQkGYqqnAGCscYd6RNeXfGeiuCphsPtqyIfQ==}
 
   '@cacheable/net@2.1.0':
     resolution: {integrity: sha512-DlLnk6EWquHuFKd7sMQop4/mKwYRxU36ZAn1JrvvJzTed8JmOGlJ6InzOXUqyXs8duP3LhmN1fNmBUwx4ChD3g==}
-
-  '@cacheable/utils@2.4.1':
-    resolution: {integrity: sha512-eiFgzCbIneyMlLOmNG4g9xzF7Hv3Mga4LjxjcSC/ues6VYq2+gUbQI8JqNuw/ZM8tJIeIaBGpswAsqV2V7ApgA==}
 
   '@cacheable/utils@2.5.0':
     resolution: {integrity: sha512-buipgOVDkkPXNR5+xBpDw7Zk2n1EvU7qBJCNUcL7rhQ//kfpOXPAvQ511Os0vpLYJ1pZnvudNytkQt2hst3wqA==}
@@ -1029,9 +1023,6 @@ packages:
   cac@7.0.0:
     resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
     engines: {node: '>=20.19.0'}
-
-  cacheable@2.3.5:
-    resolution: {integrity: sha512-EQfaKe09tl615iNvq/TBRWTFf1AKJNXYQSsMx0Z3EI0nA+pVsVPS8wJhnRlkbdacKPh1d0qVIhwTc2zsQNFEEg==}
 
   cacheable@2.5.0:
     resolution: {integrity: sha512-60cyAOytib/OzBw1JNSoSV/boK1AtHryDIjvVBk7XbN4ugfkM3+Sry7fEjNgPMGgOjuaZPAp8ruZ0Cxafwyq9g==}
@@ -2632,13 +2623,6 @@ snapshots:
   '@biomejs/cli-win32-x64@2.5.3':
     optional: true
 
-  '@cacheable/memory@2.0.8':
-    dependencies:
-      '@cacheable/utils': 2.4.1
-      '@keyv/bigmap': 1.3.1(keyv@5.6.0)
-      hookified: 1.15.1
-      keyv: 5.6.0
-
   '@cacheable/memory@2.2.0':
     dependencies:
       '@cacheable/utils': 2.5.0
@@ -2653,11 +2637,6 @@ snapshots:
       hookified: 1.15.1
       http-cache-semantics: 4.2.0
       undici: 7.25.0
-
-  '@cacheable/utils@2.4.1':
-    dependencies:
-      hashery: 1.5.1
-      keyv: 5.6.0
 
   '@cacheable/utils@2.5.0':
     dependencies:
@@ -2776,7 +2755,7 @@ snapshots:
 
   '@jaredwray/fumanchu@4.7.0':
     dependencies:
-      '@cacheable/memory': 2.0.8
+      '@cacheable/memory': 2.2.0
       chrono-node: 2.9.0
       dayjs: 1.11.20
       ent: 2.2.2
@@ -3228,14 +3207,6 @@ snapshots:
 
   cac@7.0.0: {}
 
-  cacheable@2.3.5:
-    dependencies:
-      '@cacheable/memory': 2.0.8
-      '@cacheable/utils': 2.4.1
-      hookified: 1.15.1
-      keyv: 5.6.0
-      qified: 0.10.1
-
   cacheable@2.5.0:
     dependencies:
       '@cacheable/memory': 2.2.0
@@ -3401,7 +3372,7 @@ snapshots:
   ecto@4.8.7(@types/react@19.2.17):
     dependencies:
       '@jaredwray/fumanchu': 4.7.0
-      cacheable: 2.3.5
+      cacheable: 2.5.0
       ejs: 5.0.2
       ent: 2.2.2
       hookified: 2.2.0
@@ -5100,7 +5071,7 @@ snapshots:
   writr@6.1.2(@types/react@19.2.17):
     dependencies:
       ai: 6.0.203(zod@4.4.3)
-      cacheable: 2.3.5
+      cacheable: 2.5.0
       hashery: 2.0.0
       hookified: 2.2.0
       html-react-parser: 6.1.3(@types/react@19.2.17)(react@19.2.7)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests pass with 100% code coverage (dependency-only change — no new tests required).

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Chore / dependency maintenance — **runtime phase** (first of the runtime-dependency PRs). Upgrades the caching runtime dependency (`cacheable`, used by `writr-cache.ts`). Minor version bump; no source or behavior changes.

## Versions
- `cacheable` `^2.3.5` → `^2.5.0`

## Tests
- [x] `pnpm build` passes
- [x] `pnpm test` passes — 186 tests, 100% statement coverage (includes the cache suite)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bx1tkmgsxoZ7DqJKQGn1hU)_