### PR TITLE
root - chore: upgrade html-react-parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "cacheable": "^2.5.0",
     "hashery": "^3.0.1",
     "hookified": "^3.0.1",
-    "html-react-parser": "^6.1.3",
+    "html-react-parser": "^6.1.4",
     "js-yaml": "^4.2.0",
     "react": "^19.2.7",
     "rehype-highlight": "^7.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^3.0.1
         version: 3.0.1
       html-react-parser:
-        specifier: ^6.1.3
-        version: 6.1.3(@types/react@19.2.17)(react@19.2.7)
+        specifier: ^6.1.4
+        version: 6.1.4(@types/react@19.2.17)(react@19.2.7)
       js-yaml:
         specifier: ^4.2.0
         version: 4.2.0
@@ -1457,6 +1457,15 @@ packages:
       '@types/react':
         optional: true
 
+  html-react-parser@6.1.4:
+    resolution: {integrity: sha512-oNZVIuYir7XOFuQZ7mtvcIC5cTYBVqCDOhJ1rSH4V1nVDs71bHZXFlKdpSuOm5TZT7V2uxCxA7HqTkCNHW32KQ==}
+    peerDependencies:
+      '@types/react': 0.14 || 15 || 16 || 17 || 18 || 19
+      react: 0.14 || 15 || 16 || 17 || 18 || 19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
@@ -2228,8 +2237,14 @@ packages:
   style-to-js@2.0.0:
     resolution: {integrity: sha512-amkl/SwHF/Gb430+eOiN+XToZ6VsD2nota1kCXps4k1xagZOniEVNm8zKYm7RrGm2Q6d6hjnZdqebFIunoSJng==}
 
+  style-to-js@2.0.1:
+    resolution: {integrity: sha512-j5whjFV29FyWf+/gWc/Fax7DQqojc5CzZ2kxOCuSMoZDGdciF+Ki1HyZ/GPOxdbfIw0suKUBmG1I3qa7JZKRTA==}
+
   style-to-object@1.0.14:
     resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
+
+  style-to-object@2.0.0:
+    resolution: {integrity: sha512-3zaRtBpwCy9AnYQYfgZ8tIMPn/PlQpW3wtRMB+w0xVtBzo8/m7KKGi7cR56yQ6udLz5MPzwRqfKOZ3O+Oc6VpA==}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -3701,6 +3716,16 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
+  html-react-parser@6.1.4(@types/react@19.2.17)(react@19.2.7):
+    dependencies:
+      domhandler: 6.0.1
+      html-dom-parser: 8.0.0
+      react: 19.2.7
+      react-property: 2.0.2
+      style-to-js: 2.0.1
+    optionalDependencies:
+      '@types/react': 19.2.17
+
   html-void-elements@3.0.0: {}
 
   htmlparser2@12.0.0:
@@ -4830,7 +4855,15 @@ snapshots:
     dependencies:
       style-to-object: 1.0.14
 
+  style-to-js@2.0.1:
+    dependencies:
+      style-to-object: 2.0.0
+
   style-to-object@1.0.14:
+    dependencies:
+      inline-style-parser: 0.2.7
+
+  style-to-object@2.0.0:
     dependencies:
       inline-style-parser: 0.2.7
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests pass with 100% code coverage (dependency-only change — no new tests required).

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Chore / dependency maintenance — runtime phase. Patch bump of `html-react-parser` (Writr's HTML-to-React rendering). This is the last non-major runtime upgrade; the `ai` and `js-yaml` majors follow as their own reviewed PRs. No source or behavior changes.

## Versions
- `html-react-parser` `^6.1.3` → `^6.1.4`

## Tests
- [x] `pnpm build` passes
- [x] `pnpm test` passes — 186 tests, 100% statement coverage (includes the React rendering suite)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bx1tkmgsxoZ7DqJKQGn1hU)_