### PR TITLE
release: v6.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "writr",
-  "version": "6.1.4",
+  "version": "6.1.5",
   "description": "Markdown Rendering Simplified",
   "type": "module",
   "packageManager": "pnpm@11.6.0",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
  - Release cut — the diff is a one-line `package.json` version bump, so there is no behavior to test. The existing suite passes unchanged.

**What kind of change does this PR introduce?**

Release — cuts `writr@6.1.5` (patch). No source change.

## Release summary

Widens `engines.node` to allow Node 24+; adds the unpublished `writr-rs` Rust engine workspace.

## Packages

| Package | Current | New | Bump | Rationale | Commits |
|---|---|---|---|---|---|
| `writr` | `6.1.4` | `6.1.5` | **patch** | 1 fix, 21 internal, 1 ci | 23 |

## writr@6.1.5 — 2026-07-25

Widens `engines.node` to allow Node 24+; adds the unpublished `writr-rs` Rust engine workspace.

### Bug Fixes
- allow Node 24+ in `engines.node` — `^22.18.0` resolves to `>=22.18.0 <23.0.0`, excluding the Node versions writr is tested on, so installs under `engine-strict=true` aborted with `ERR_PNPM_UNSUPPORTED_ENGINE` (cf8efa4, #488)

### Internal
- writr-rs: byte-exact Rust markdown engine — Cargo workspace with a commonmark-exact core, GFM alerts, toc/emoji/slug transforms, raw-HTML replay over html5ever, a highlight.js 11.11.1 engine port, and a KaTeX 0.16.45 bridge (097608b, 5997924, 684b143, 0ddec57, fc83338, f425e5f, #487)
- writr-rs: napi bindings (native + wasm32-wasip1 + browser ESM) with golden-harness parity across all 2,041 goldens on seven profiles, plus packed `renderBatchBuffer` batch rendering (a51b7d6, bacd8d9, 126ca04, #487)
- writr-rs: optimization pass — streaming serializer, copy-free hljs hot loop, 40-byte `u32` parser events, `wasm-opt -O3` + SIMD128, opt-in PGO build (87e09f0, 708a55e, 06c0fa4, 758e6ef, ef79f3c, a77fe00, f97d743, #487)
- add `build:rs`, `build:rs:wasm`, and `build:rs:pgo` scripts plus `benchmark/benchmark-rust.ts` (#487)
- add `.github/workflows/writr-rs.yml` — fmt, clippy `-D warnings`, tests, coverage gate, codegen-freshness check, harness parity, native build matrix (b676fde, e68b3c4, edaa457, b19791f, #487)
- refresh performance numbers after the M10 optimization pass (e88ce86, #487)
- pin browser install to the pinned playwright-core (f70fa36, #488)

### Notes
- **The published package's runtime is unchanged in this release.** `src/**` has zero changes since `v6.1.4`, so `dist/` builds byte-identical to `6.1.4`. `writr-rs/` is not part of the npm tarball (`files: ["dist", "README.md", "LICENSE"]`) — it is built from source via `pnpm build:rs`. The only tarball-affecting change is the `engines.node` widening, which is why this is a patch rather than a minor.

### Contributors
- @jaredwray (23 — writr-rs commits agent-authored)

### Full List of Changes
- writr-rs: byte-exact Rust markdown engine (native + wasm + browser) with multi-core rendering by @jaredwray in #487
- root - fix: allow Node 24+ in engines.node by @jaredwray in #488

**Full diff:** https://github.com/jaredwray/writr/compare/v6.1.4...v6.1.5

## Verification
- [x] `pnpm install --frozen-lockfile` succeeds — no lockfile change (`engines` and the root version do not affect resolution)
- [x] `pnpm build` succeeds
- [x] `pnpm test:ci` passes locally — 186 tests, 100% statements / 100% functions / 100% lines / 98.76% branches
- [x] No uncommitted changes outside the version bump

## Branch naming

This release would normally ship from `release/v6.1.5`. The environment that produced it pins the session to `claude/writr-release-cut-yo4vt8`, so the cut ships from that branch instead. Contents are unaffected — a single version-bump commit.

## Post-merge

Merge, then create a GitHub Release at tag `v6.1.5` — `.github/workflows/release.yml` triggers on `release: [released]` and publishes to npm with provenance.

---
_Generated by [Claude Code](https://claude.ai/code/session_017TNP3RDia7XPJhyqrPRanV)_