### PR TITLE
root - chore: upgrade hookified

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "ai": "^7.0.64",
     "cacheable": "^2.5.0",
     "hashery": "^3.0.1",
-    "hookified": "^3.0.1",
+    "hookified": "^3.0.2",
     "html-react-parser": "^6.1.5",
     "js-yaml": "^5.2.1",
     "react": "^19.2.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^3.0.1
         version: 3.0.1
       hookified:
-        specifier: ^3.0.1
-        version: 3.0.1
+        specifier: ^3.0.2
+        version: 3.0.2
       html-react-parser:
         specifier: ^6.1.5
         version: 6.1.5(@types/react@19.2.18)(react@19.2.8)
@@ -1591,8 +1591,8 @@ packages:
   hookified@2.2.0:
     resolution: {integrity: sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==}
 
-  hookified@3.0.1:
-    resolution: {integrity: sha512-mtpUIV7U9reosQ16+OHWBd0Ca07fs1ryChQjBPuUMZnrRdLTCW+kEfkTcFudkaevp3gVe5H9FxDCBxYIdO+QQA==}
+  hookified@3.0.2:
+    resolution: {integrity: sha512-FpIcRHpFlW7yh68lmL0h1/Vodv77TogpHlt4qqakE/0RyQMjgNxs53acH9NJPeyRZutP7GnlqiyqRNejV8/lHQ==}
     engines: {node: '>=22.18.0'}
 
   html-dom-parser@8.0.0:
@@ -3804,11 +3804,11 @@ snapshots:
 
   hashery@3.0.0:
     dependencies:
-      hookified: 3.0.1
+      hookified: 3.0.2
 
   hashery@3.0.1:
     dependencies:
-      hookified: 3.0.1
+      hookified: 3.0.2
 
   hasown@2.0.3:
     dependencies:
@@ -3930,7 +3930,7 @@ snapshots:
 
   hookified@2.2.0: {}
 
-  hookified@3.0.1: {}
+  hookified@3.0.2: {}
 
   html-dom-parser@8.0.0:
     dependencies:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Upgrade standalone runtime dependency `hookified` to the latest `minimumReleaseAge`-gated version.

## Changes
- bump `hookified` 3.0.1 → 3.0.2

## Verification
- [x] `pnpm build` passes
- [x] `pnpm test` passes (186 tests)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-70fb27c0-fba1-4d5a-a6e1-cea24cc79cea?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-70fb27c0-fba1-4d5a-a6e1-cea24cc79cea&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

