### PR TITLE
workspace - chore: upgrade GitHub Actions

### DIFF
--- a/.github/workflows/writr-rs.yml
+++ b/.github/workflows/writr-rs.yml
@@ -56,7 +56,7 @@ jobs:
           done
         working-directory: writr-rs
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@3ee274a48739f9c49921feda61cb199dc7520e62 # cargo-llvm-cov
+        uses: taiki-e/install-action@b549cefc011fbb8c6ea6125469ebafdb8f24bd7d # cargo-llvm-cov
         with:
           tool: cargo-llvm-cov
       # 97.75% at gate introduction; every uncovered line is documented as


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Refresh the SHA pin for `taiki-e/install-action` (`cargo-llvm-cov`) to the current tip. Other workflow action SHAs are already current.

## Changes
- bump `taiki-e/install-action` `3ee274a…` → `b549cef…` in `writr-rs.yml` (comment remains `cargo-llvm-cov`)

## Verification
- [x] workflow YAML parses (`writr-rs.yml`)
- [x] audited other action SHAs — already at tip for their pinned refs
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-70fb27c0-fba1-4d5a-a6e1-cea24cc79cea?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-70fb27c0-fba1-4d5a-a6e1-cea24cc79cea&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

