### PR TITLE
workspace - chore: upgrade fancy-regex to 0.19.0 (breaking)

### DIFF
--- a/writr-rs/Cargo.lock
+++ b/writr-rs/Cargo.lock
@@ -232,9 +232,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "fancy-regex"
-version = "0.16.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
+checksum = "476de73bddf2ef8490aa4ee8f1cf40b430bf1d56c48c22080e5186952cd580e6"
 dependencies = [
  "bit-set",
  "regex-automata",

--- a/writr-rs/crates/writr-hljs/Cargo.toml
+++ b/writr-rs/crates/writr-hljs/Cargo.toml
@@ -8,7 +8,7 @@ rust-version.workspace = true
 description = "highlight.js 11.11.1 engine port for writr-rs — byte-compatible hljs tokenization"
 
 [dependencies]
-fancy-regex = "0.16"
+fancy-regex = "0.19.0"
 regex = "1"
 rustc-hash = "2"
 serde = { workspace = true }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Upgrade `fancy-regex` in `writr-hljs` to the latest `cargo outdated` Latest version.

## Changes
- bump `fancy-regex` 0.16.2 → 0.19.0 in `writr-rs/crates/writr-hljs`
- refresh `Cargo.lock`

## Verification
- [x] `cargo build --workspace --all-targets`
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt -- --check`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-70fb27c0-fba1-4d5a-a6e1-cea24cc79cea?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-70fb27c0-fba1-4d5a-a6e1-cea24cc79cea&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

