### PR TITLE
workspace - chore: upgrade rquickjs to 0.12.2

### DIFF
--- a/writr-rs/Cargo.lock
+++ b/writr-rs/Cargo.lock
@@ -716,18 +716,18 @@ dependencies = [
 
 [[package]]
 name = "rquickjs"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ce6b626d30ecbedaaf8097a04982bc3b081f958f5bdf9b8796be4ac00ee48bb"
+checksum = "4e04e4eedfb060b503b5f0a2644abb890b0b3620d3fb674f9455f230014964e4"
 dependencies = [
  "rquickjs-core",
 ]
 
 [[package]]
 name = "rquickjs-core"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9334dd11023d5ae6c751f64496510a576208802ed1d022ef94afa7639c2c55e"
+checksum = "16e4f499ac5b943d97ee6dbc44f23c2c10426f420f7d2f1793d6318911b6608c"
 dependencies = [
  "hashbrown",
  "relative-path",
@@ -736,9 +736,9 @@ dependencies = [
 
 [[package]]
 name = "rquickjs-sys"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eef73520804cf5aa4876097ac5733058d628c769eba9678e0f4dba5a4ef79703"
+checksum = "a13ac243b86a74120814ef7e9e30ad5a2c1199b7b9963b1cf7c84e4cdc1cad99"
 dependencies = [
  "cc",
 ]

--- a/writr-rs/crates/writr-katex/Cargo.toml
+++ b/writr-rs/crates/writr-katex/Cargo.toml
@@ -8,4 +8,4 @@ rust-version.workspace = true
 description = "KaTeX 0.16.45 for writr-rs — the real katex.min.js on an embedded QuickJS"
 
 [dependencies]
-rquickjs = { version = "0.12", features = ["classes"] }
+rquickjs = { version = "0.12.2", features = ["classes"] }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Upgrade `rquickjs` in `writr-katex` to the latest `cargo outdated` Latest version.

## Changes
- bump `rquickjs` 0.12.1 → 0.12.2 in `writr-rs/crates/writr-katex`
- refresh `Cargo.lock` (`rquickjs-core` / `rquickjs-sys` 0.12.2)

## Verification
- [x] `cargo build --workspace --all-targets`
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt -- --check`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-70fb27c0-fba1-4d5a-a6e1-cea24cc79cea?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-70fb27c0-fba1-4d5a-a6e1-cea24cc79cea&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

