### PR TITLE
writr - chore: defense - stage npm releases via OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,5 +65,15 @@ jobs:
     - name: Testing
       run: pnpm test:ci
 
-    - name: Publish
-      run: pnpm publish --access public --no-git-checks --provenance
+    - name: Pack
+      run: |
+        mkdir -p packed
+        pnpm pack --pack-destination packed
+        ls -la packed
+
+    - name: Ensure npm CLI for staged publishing
+      # zizmor: ignore[adhoc-packages] pin npm 11.19.0 so `npm stage publish` is available
+      run: npm install --global npm@11.19.0
+
+    - name: Stage publish
+      run: npm stage publish packed/*.tgz --access public --provenance

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -47,7 +47,7 @@ Profile: npm library · public
 ## 5. npm publishing — npm libraries only
 
 - [ ] OIDC trusted publishing configured **stage-only** on npmjs.com for the publish workflow — it can stage, never publish live (manual)
-- [ ] Staged publishing: CI runs `npm stage publish`; a maintainer promotes with 2FA (PR pending)
+- [ ] Staged publishing: CI runs `npm stage publish`; a maintainer promotes with 2FA (PR #507 pending)
 - [ ] Drydock connected — staged releases reviewed before promotion (manual)
 - [ ] No direct publish rights: package requires 2FA and disallows tokens (manual)
 - [x] `package.json` `repository.url` accurate so provenance maps to this repo — verified 2026-08-15

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -6,8 +6,8 @@ Profile: npm library · public
 
 ## 1. Security docs
 
-- [ ] `SECURITY.md` present — contact info + "How this repository is secured" summary (PR #506 pending)
-- [ ] `DEFENSE_IN_DEPTH.md` present (this file) (PR #506 pending)
+- [x] `SECURITY.md` present — contact info + "How this repository is secured" summary — PR #506
+- [x] `DEFENSE_IN_DEPTH.md` present (this file) — PR #506
 
 ## 2. Repository lockdown
 
@@ -28,32 +28,32 @@ Profile: npm library · public
 ## 3. Dependencies (pnpm)
 
 - [x] `packageManager: pnpm@11.x` pinned in `package.json` — verified 2026-08-15 (`pnpm@11.21.0`)
-- [ ] 7-day cooldown: `minimumReleaseAge: 10080`, `minimumReleaseAgeStrict: true`, `minimumReleaseAgeIgnoreMissingTime: false` (PR #506 pending)
-- [ ] Lifecycle scripts blocked: `strictDepBuilds: true`, `dangerouslyAllowAllBuilds: false`, `allowBuilds: {}` baseline (PR #506 pending)
-- [ ] `blockExoticSubdeps: true` (PR #506 pending)
-- [ ] Lockfile committed; CI installs with `pnpm install --frozen-lockfile` (PR #506 pending)
+- [x] 7-day cooldown: `minimumReleaseAge: 10080`, `minimumReleaseAgeStrict: true`, `minimumReleaseAgeIgnoreMissingTime: false` — PR #506
+- [x] Lifecycle scripts blocked: `strictDepBuilds: true`, `dangerouslyAllowAllBuilds: false`, `allowBuilds: {}` baseline — PR #506 (default-deny; reviewed exceptions for `esbuild` and `unrs-resolver`)
+- [x] `blockExoticSubdeps: true` — PR #506
+- [x] Lockfile committed; CI installs with `pnpm install --frozen-lockfile` — PR #506
 - [x] Dependency-update tooling opens PRs only — never auto-merge — verified 2026-08-15 (Dependabot Updates active; no auto-merge config in-repo)
-- [ ] New direct dependencies get human review; prefer `~` ranges over `^` (PR #506 pending)
+- [x] New direct dependencies get human review; prefer `~` ranges over `^` — PR #506
 
 ## 4. GitHub Actions
 
-- [ ] `permissions: contents: read` (or `{}` + per-job grants) on every workflow (PR #506 pending)
+- [x] `permissions: contents: read` (or `{}` + per-job grants) on every workflow — PR #506
 - [x] Every action pinned to a full commit SHA (`npx actions-up`) — verified 2026-08-15
-- [ ] `.github/workflows/check-workflows.yaml` lints workflows with zizmor on every PR (PR #506 pending)
-- [ ] `persist-credentials: false` on checkouts that don't push (PR #506 pending)
+- [x] `.github/workflows/check-workflows.yaml` lints workflows with zizmor on every PR — PR #506
+- [x] `persist-credentials: false` on checkouts that don't push — PR #506
 - [x] No `pull_request_target` on workflows that run untrusted PR code — verified 2026-08-15
 - [x] No npm tokens (or other registry credentials) in Actions secrets — verified 2026-08-15 (no workflow references `NPM_TOKEN` / `NODE_AUTH_TOKEN`; publish uses OIDC provenance)
 
 ## 5. npm publishing — npm libraries only
 
 - [ ] OIDC trusted publishing configured **stage-only** on npmjs.com for the publish workflow — it can stage, never publish live (manual)
-- [ ] Staged publishing: CI runs `npm stage publish`; a maintainer promotes with 2FA (manual)
+- [ ] Staged publishing: CI runs `npm stage publish`; a maintainer promotes with 2FA (PR pending)
 - [ ] Drydock connected — staged releases reviewed before promotion (manual)
 - [ ] No direct publish rights: package requires 2FA and disallows tokens (manual)
 - [x] `package.json` `repository.url` accurate so provenance maps to this repo — verified 2026-08-15
 
 ## 6. Security tooling
 
-- [ ] Aikido runs on every build
-- [ ] Aikido release gate: the release workflow's stage-publish job `needs:` a passing `scan-release` (PR #506 pending)
+- [x] Aikido runs on every build — verified 2026-08-15 (GitHub check "Aikido Security: check code" passed on PR #506)
+- [x] Aikido release gate: the release workflow's stage-publish job `needs:` a passing `scan-release` — PR #506
 - [x] Socket reviews every PR that changes dependencies — verified 2026-08-15 (GitHub checks "Socket Security: Pull Request Alerts" and "Project Report" on PR #506)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,5 +23,5 @@ We will acknowledge receipt, work with you on a coordinated disclosure timeline,
 This repository follows the [defense-in-depth](https://github.com/jaredwray/agentic/blob/main/skills/security/defense-in-depth-nodejs/SKILL.md) hardening checklist; progress is tracked in [DEFENSE_IN_DEPTH.md](./DEFENSE_IN_DEPTH.md). Measures currently in place:
 
 - CI runs with read-only permissions; every action is pinned to a full commit SHA and workflows are security-linted with zizmor on every PR.
-- Dependencies install through pnpm with a 7-day cooldown on new versions, and lifecycle scripts are blocked by default. CI installs with a frozen lockfile. Socket reviews every dependency change.
-- npm releases are published with provenance via GitHub Actions OIDC trusted publishing. The publish workflow does not use an npm token.
+- Dependencies install through pnpm with a 7-day cooldown on new versions, and lifecycle scripts are blocked by default. CI installs with a frozen lockfile. Socket reviews every dependency change; Aikido scans every build.
+- npm releases are staged via GitHub Actions OIDC trusted publishing (`npm stage publish` with provenance). A maintainer promotes the staged version with 2FA. The publish workflow does not use an npm token.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Switch the release workflow from a live `pnpm publish` to `npm stage publish` of a packed tarball (defense-in-depth-nodejs § 5). CI can enqueue a version; a maintainer promotes it with 2FA.

## Changes

- Pack with `pnpm pack`, pin npm CLI 11.19.0, then `npm stage publish packed/*.tgz --access public --provenance`.
- Reconcile `DEFENSE_IN_DEPTH.md` for merged PR #506 (docs, pnpm, Actions, Aikido gate). Mark Aikido-on-every-build verified from PR #506 checks.
- Update `SECURITY.md` so the live summary matches staged publishing + Aikido.

## Status update

`DEFENSE_IN_DEPTH.md`: Staged publishing CI → `(PR #507 pending)`.

## Verification

- [x] `pnpm help pack` confirms `--pack-destination`
- [x] npm 11.19.0 is older than the 7-day cooldown cutoff and includes `npm stage`
- [x] GitHub CI green on this PR (tests, zizmor, CodeQL, Socket)

## Maintainer follow-up (npmjs.com, still manual)

Before the next GitHub Release, on the `writr` package:

1. Trusted publisher for workflow `release.yml`: allow **`npm stage publish` only** (stage-only)
2. Connect [Drydock](https://drydock.org)
3. Package access: require 2FA and disallow tokens

Trusted publishers created before May 2026 default to `npm publish` only — this workflow will fail at stage until the publisher allows `npm stage publish`. Also add `AIKIDO_CLIENT_API_KEY` or the Aikido gate will fail.

§ 2 repository lockdown is deferred (you said you will apply it last on another instance).

## Breaking notes

The next GitHub Release no longer publishes live to npm. It stages a version. Promote with 2FA after Drydock review.

Reference: `defense-in-depth-nodejs § 5`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55303b82-7e77-4a66-9087-b8d64bcaffbd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55303b82-7e77-4a66-9087-b8d64bcaffbd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

