### PR TITLE
writr - chore: defense - record npm stage-only, Drydock, and 2FA

### DIFF
--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -46,7 +46,7 @@ Profile: npm library · public
 
 ## 5. npm publishing — npm libraries only
 
-- [ ] OIDC trusted publishing configured **stage-only** on npmjs.com for the publish workflow — it can stage, never publish live (manual)
+- [x] OIDC trusted publishing configured **stage-only** on npmjs.com for the publish workflow — it can stage, never publish live — verified 2026-08-15 (maintainer)
 - [x] Staged publishing: CI runs `npm stage publish`; a maintainer promotes with 2FA — PR #507
 - [x] Drydock connected — staged releases reviewed before promotion — verified 2026-08-15 (maintainer)
 - [ ] No direct publish rights: package requires 2FA and disallows tokens (manual)

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -49,7 +49,7 @@ Profile: npm library · public
 - [x] OIDC trusted publishing configured **stage-only** on npmjs.com for the publish workflow — it can stage, never publish live — verified 2026-08-15 (maintainer)
 - [x] Staged publishing: CI runs `npm stage publish`; a maintainer promotes with 2FA — PR #507
 - [x] Drydock connected — staged releases reviewed before promotion — verified 2026-08-15 (maintainer)
-- [ ] No direct publish rights: package requires 2FA and disallows tokens (manual)
+- [x] No direct publish rights: package requires 2FA and disallows tokens — verified 2026-08-15 (maintainer)
 - [x] `package.json` `repository.url` accurate so provenance maps to this repo — verified 2026-08-15
 
 ## 6. Security tooling

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -47,8 +47,8 @@ Profile: npm library · public
 ## 5. npm publishing — npm libraries only
 
 - [ ] OIDC trusted publishing configured **stage-only** on npmjs.com for the publish workflow — it can stage, never publish live (manual)
-- [ ] Staged publishing: CI runs `npm stage publish`; a maintainer promotes with 2FA (PR #507 pending)
-- [ ] Drydock connected — staged releases reviewed before promotion (manual)
+- [x] Staged publishing: CI runs `npm stage publish`; a maintainer promotes with 2FA — PR #507
+- [x] Drydock connected — staged releases reviewed before promotion — verified 2026-08-15 (maintainer)
 - [ ] No direct publish rights: package requires 2FA and disallows tokens (manual)
 - [x] `package.json` `repository.url` accurate so provenance maps to this repo — verified 2026-08-15
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,4 +24,4 @@ This repository follows the [defense-in-depth](https://github.com/jaredwray/agen
 
 - CI runs with read-only permissions; every action is pinned to a full commit SHA and workflows are security-linted with zizmor on every PR.
 - Dependencies install through pnpm with a 7-day cooldown on new versions, and lifecycle scripts are blocked by default. CI installs with a frozen lockfile. Socket reviews every dependency change; Aikido scans every build.
-- npm releases are staged via GitHub Actions OIDC trusted publishing (`npm stage publish` with provenance). Drydock reviews the staged artifact; a maintainer promotes with 2FA. The publish workflow does not use an npm token.
+- npm releases are staged, never published directly: CI authenticates with **stage-only** OIDC trusted publishing (`npm stage publish` with provenance). Drydock reviews the staged artifact; a maintainer promotes with 2FA. The publish workflow does not use an npm token.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,4 +24,4 @@ This repository follows the [defense-in-depth](https://github.com/jaredwray/agen
 
 - CI runs with read-only permissions; every action is pinned to a full commit SHA and workflows are security-linted with zizmor on every PR.
 - Dependencies install through pnpm with a 7-day cooldown on new versions, and lifecycle scripts are blocked by default. CI installs with a frozen lockfile. Socket reviews every dependency change; Aikido scans every build.
-- npm releases are staged, never published directly: CI authenticates with **stage-only** OIDC trusted publishing (`npm stage publish` with provenance). Drydock reviews the staged artifact; a maintainer promotes with 2FA. The publish workflow does not use an npm token.
+- npm releases are staged, never published directly: CI authenticates with **stage-only** OIDC trusted publishing (`npm stage publish` with provenance). Drydock reviews the staged artifact; a maintainer promotes with 2FA. The package requires 2FA and disallows tokens.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,4 +24,4 @@ This repository follows the [defense-in-depth](https://github.com/jaredwray/agen
 
 - CI runs with read-only permissions; every action is pinned to a full commit SHA and workflows are security-linted with zizmor on every PR.
 - Dependencies install through pnpm with a 7-day cooldown on new versions, and lifecycle scripts are blocked by default. CI installs with a frozen lockfile. Socket reviews every dependency change; Aikido scans every build.
-- npm releases are staged via GitHub Actions OIDC trusted publishing (`npm stage publish` with provenance). A maintainer promotes the staged version with 2FA. The publish workflow does not use an npm token.
+- npm releases are staged via GitHub Actions OIDC trusted publishing (`npm stage publish` with provenance). Drydock reviews the staged artifact; a maintainer promotes with 2FA. The publish workflow does not use an npm token.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Record npmjs.com § 5 settings that are now live for `writr`: Drydock, **stage-only** OIDC trusted publishing, and **2FA + disallow tokens**. `SECURITY.md` only lists controls that are actually in place.

## Changes

- Check off Drydock, stage-only OIDC, and 2FA/disallow tokens (maintainer confirmed).
- Mark staged publishing CI as merged — PR #507.
- Update the public security summary to match.

## Status update

`DEFENSE_IN_DEPTH.md` § 5 npm publishing is complete on this PR (except it already had `repository.url`).

## Verification

- [x] Maintainer confirmed Drydock npm access
- [x] Maintainer confirmed OIDC trusted publisher is stage-only
- [x] Maintainer confirmed package requires 2FA and disallows tokens

## Still open

- Repo secret `AIKIDO_CLIENT_API_KEY` before the next GitHub Release
- § 2 repository lockdown (deferred to another instance)
- Account manuals: phishing-resistant 2FA, recovery codes, VM egress

Reference: `defense-in-depth-nodejs § 5`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55303b82-7e77-4a66-9087-b8d64bcaffbd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55303b82-7e77-4a66-9087-b8d64bcaffbd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

