### PR TITLE
chore: replace dummy secrets in benchmark markdown fixtures

### DIFF
--- a/benchmark/benchmark-contents.ts
+++ b/benchmark/benchmark-contents.ts
@@ -1978,7 +1978,7 @@ last_updated: "2024-12-01"
 All API requests require a Bearer token:
 
 \`\`\`bash
-curl -H "Authorization: Bearer YOUR_TOKEN" \\
+curl -H "Authorization: Bearer $TOKEN" \\
      https://api.example.com/v2/users
 \`\`\`
 
@@ -2199,7 +2199,7 @@ title: "Environment Variables"
 | Variable | Description | Example |
 |----------|-------------|---------|
 | DATABASE_URL | Database connection | postgres://... |
-| API_KEY | API authentication | sk_live_... |
+| API_KEY | API authentication | $API_KEY |
 | NODE_ENV | Environment | production |
 
 ## Optional Variables
@@ -2213,8 +2213,8 @@ title: "Environment Variables"
 ## Example .env
 
 \`\`\`bash
-DATABASE_URL=postgres://user:pass@localhost:5432/db
-API_KEY=sk_live_abcd1234
+DATABASE_URL=postgres://localhost:5432/example
+API_KEY=$API_KEY
 NODE_ENV=development
 PORT=3000
 \`\`\`

--- a/test/benchmark-contents.test.ts
+++ b/test/benchmark-contents.test.ts
@@ -1,0 +1,19 @@
+import fs from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const contentsPath = "./benchmark/benchmark-contents.ts";
+
+describe("benchmark markdown fixtures", () => {
+	it("does not embed secret-scanner bait in example snippets", () => {
+		const source = fs.readFileSync(contentsPath, "utf8");
+
+		// Aikido/gitleaks treat `Authorization: Bearer <word>` as a live token.
+		expect(source).not.toMatch(
+			/Authorization:\s*Bearer\s+[A-Za-z0-9._-]{8,}/,
+		);
+		expect(source).not.toMatch(/\bsk_(?:live|test)_/);
+		expect(source).not.toMatch(
+			/(?:postgres|mysql|mongodb|redis):\/\/[^/\s:]+:[^@\s]+@/i,
+		);
+	});
+});

--- a/test/benchmark-contents.test.ts
+++ b/test/benchmark-contents.test.ts
@@ -8,9 +8,7 @@ describe("benchmark markdown fixtures", () => {
 		const source = fs.readFileSync(contentsPath, "utf8");
 
 		// Aikido/gitleaks treat `Authorization: Bearer <word>` as a live token.
-		expect(source).not.toMatch(
-			/Authorization:\s*Bearer\s+[A-Za-z0-9._-]{8,}/,
-		);
+		expect(source).not.toMatch(/Authorization:\s*Bearer\s+[A-Za-z0-9._-]{8,}/);
 		expect(source).not.toMatch(/\bsk_(?:live|test)_/);
 		expect(source).not.toMatch(
 			/(?:postgres|mysql|mongodb|redis):\/\/[^/\s:]+:[^@\s]+@/i,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** Bug fix (secret-scanner false positive)

## Summary

Aikido reported a High secret in `benchmark/benchmark-contents.ts` at commit `820762b`:

```
curl -H "Authorization: Bearer YOUR_TOKEN"
```

That value is a documentation placeholder inside synthetic markdown used only as a render corpus. It is not a live API key and has never been one — it was added in the original benchmarks commit and never changed.

This PR removes the scanner-bait strings from HEAD:

- `Authorization: Bearer YOUR_TOKEN` → `Authorization: Bearer $TOKEN` (env injection, which is what Aikido recommends)
- Nearby dummy Stripe-style `sk_live_...` / `sk_live_abcd1234` and `postgres://user:pass@...` examples, so the next scan does not file the same class of finding
- A regression test that fails if those patterns return

## What this does not do

Aikido is correct that the old string remains in git history. Rewriting history of a public, published package for a dummy `YOUR_TOKEN` is not the right fix.

After this lands, **mark the Aikido issue as ignored / false positive** in the Aikido UI. Their own note says exposed-secret findings stay open until that is done manually, even after the current tree is clean.

Do not rotate any credentials — there is nothing to rotate.

## Verification

- [x] `pnpm build`
- [x] `pnpm test` (187 tests passed, including the new fixture scan)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-add4d70e-b702-4364-9869-b85324586ba8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-add4d70e-b702-4364-9869-b85324586ba8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

