### PR TITLE
writr - chore: defense - record repository lockdown

### DIFF
--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -11,16 +11,16 @@ Profile: npm library · public
 
 ## 2. Repository lockdown
 
-- [ ] Lockdown script run; `lockdown-repo.sh --check` passes clean
-- [ ] Pull requests required on the default branch; force pushes and deletion blocked
-- [ ] Merges blocked unless required status checks pass (`--required-checks "<repo's CI jobs>"`)
-- [ ] Tag ruleset "Tags only by admins" active
-- [ ] Workflow runs from all outside collaborators require approval
-- [ ] Default workflow token read-only; Actions cannot create or approve PRs
-- [ ] Actions allowlist: GitHub-owned + verified + explicit patterns only (`--allowed-actions`)
-- [ ] Secret scanning + push protection enabled *(plan-gated on private repos)*
+- [x] Lockdown script run; `lockdown-repo.sh --check` passes clean — verified 2026-08-15 (maintainer apply)
+- [x] Pull requests required on the default branch; force pushes and deletion blocked — verified 2026-08-15 (ruleset "Pull requests required")
+- [x] Merges blocked unless required status checks pass (`--required-checks "<repo's CI jobs>"`) — verified 2026-08-15 (`tests (22)`, `tests (24)`, `tests (26)`, `zizmor`)
+- [x] Tag ruleset "Tags only by admins" active — verified 2026-08-15
+- [x] Workflow runs from all outside collaborators require approval — verified 2026-08-15 (maintainer apply)
+- [x] Default workflow token read-only; Actions cannot create or approve PRs — verified 2026-08-15 (maintainer apply)
+- [x] Actions allowlist: GitHub-owned + verified + explicit patterns only (`--allowed-actions`) — verified 2026-08-15 (`zizmorcore/* pnpm/* codecov/* cloudflare/* dtolnay/* Swatinem/* taiki-e/*`)
+- [x] Secret scanning + push protection enabled *(plan-gated on private repos)* — verified 2026-08-15 (maintainer apply)
 - [x] Private vulnerability reporting enabled *(public repos only)* — verified 2026-08-15
-- [ ] Dependabot alerts enabled
+- [x] Dependabot alerts enabled — verified 2026-08-15 (maintainer apply)
 - [ ] Phishing-resistant 2FA (passkeys / hardware keys) on the GitHub and npm accounts (manual)
 - [ ] Recovery codes stored offline in a password manager (manual)
 - [ ] Dev/release VM network egress filtered by a firewall (e.g. PMG) (manual)

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -21,7 +21,7 @@ Profile: npm library · public
 - [x] Secret scanning + push protection enabled *(plan-gated on private repos)* — verified 2026-08-15 (maintainer `--check`)
 - [x] Private vulnerability reporting enabled *(public repos only)* — verified 2026-08-15
 - [x] Dependabot alerts enabled — verified 2026-08-15 (maintainer `--check`)
-- [ ] Phishing-resistant 2FA (passkeys / hardware keys) on the GitHub and npm accounts (manual)
+- [x] Phishing-resistant 2FA (passkeys / hardware keys) on the GitHub and npm accounts (manual) — verified 2026-08-15 (maintainer)
 - [ ] Recovery codes stored offline in a password manager (manual)
 
 ## 3. Dependencies (pnpm)

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -22,7 +22,7 @@ Profile: npm library · public
 - [x] Private vulnerability reporting enabled *(public repos only)* — verified 2026-08-15
 - [x] Dependabot alerts enabled — verified 2026-08-15 (maintainer `--check`)
 - [x] Phishing-resistant 2FA (passkeys / hardware keys) on the GitHub and npm accounts (manual) — verified 2026-08-15 (maintainer)
-- [ ] Recovery codes stored offline in a password manager (manual)
+- [x] Recovery codes stored offline in a password manager (manual) — verified 2026-08-15 (maintainer)
 
 ## 3. Dependencies (pnpm)
 

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -23,7 +23,6 @@ Profile: npm library · public
 - [x] Dependabot alerts enabled — verified 2026-08-15 (maintainer `--check`)
 - [ ] Phishing-resistant 2FA (passkeys / hardware keys) on the GitHub and npm accounts (manual)
 - [ ] Recovery codes stored offline in a password manager (manual)
-- [ ] Dev/release VM network egress filtered by a firewall (e.g. PMG) (manual)
 
 ## 3. Dependencies (pnpm)
 

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -11,16 +11,16 @@ Profile: npm library · public
 
 ## 2. Repository lockdown
 
-- [x] Lockdown script run; `lockdown-repo.sh --check` passes clean — verified 2026-08-15 (maintainer apply)
+- [x] Lockdown script run; `lockdown-repo.sh --check` passes clean — verified 2026-08-15 (maintainer `--check`)
 - [x] Pull requests required on the default branch; force pushes and deletion blocked — verified 2026-08-15 (ruleset "Pull requests required")
 - [x] Merges blocked unless required status checks pass (`--required-checks "<repo's CI jobs>"`) — verified 2026-08-15 (`tests (22)`, `tests (24)`, `tests (26)`, `zizmor`)
 - [x] Tag ruleset "Tags only by admins" active — verified 2026-08-15
-- [x] Workflow runs from all outside collaborators require approval — verified 2026-08-15 (maintainer apply)
-- [x] Default workflow token read-only; Actions cannot create or approve PRs — verified 2026-08-15 (maintainer apply)
+- [x] Workflow runs from all outside collaborators require approval — verified 2026-08-15 (maintainer `--check`)
+- [x] Default workflow token read-only; Actions cannot create or approve PRs — verified 2026-08-15 (maintainer `--check`)
 - [x] Actions allowlist: GitHub-owned + verified + explicit patterns only (`--allowed-actions`) — verified 2026-08-15 (`zizmorcore/* pnpm/* codecov/* cloudflare/* dtolnay/* Swatinem/* taiki-e/*`)
-- [x] Secret scanning + push protection enabled *(plan-gated on private repos)* — verified 2026-08-15 (maintainer apply)
+- [x] Secret scanning + push protection enabled *(plan-gated on private repos)* — verified 2026-08-15 (maintainer `--check`)
 - [x] Private vulnerability reporting enabled *(public repos only)* — verified 2026-08-15
-- [x] Dependabot alerts enabled — verified 2026-08-15 (maintainer apply)
+- [x] Dependabot alerts enabled — verified 2026-08-15 (maintainer `--check`)
 - [ ] Phishing-resistant 2FA (passkeys / hardware keys) on the GitHub and npm accounts (manual)
 - [ ] Recovery codes stored offline in a password manager (manual)
 - [ ] Dev/release VM network egress filtered by a firewall (e.g. PMG) (manual)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,6 +22,8 @@ We will acknowledge receipt, work with you on a coordinated disclosure timeline,
 
 This repository follows the [defense-in-depth](https://github.com/jaredwray/agentic/blob/main/skills/security/defense-in-depth-nodejs/SKILL.md) hardening checklist; progress is tracked in [DEFENSE_IN_DEPTH.md](./DEFENSE_IN_DEPTH.md). Measures currently in place:
 
-- CI runs with read-only permissions; every action is pinned to a full commit SHA and workflows are security-linted with zizmor on every PR.
+- All changes land through pull requests. Direct pushes to `main` are blocked; merging requires the `tests (22)`, `tests (24)`, `tests (26)`, and `zizmor` checks. Tags (releases) can only be created by repository admins.
+- CI runs with a read-only default workflow token; Actions cannot create or approve PRs. Workflow runs from outside collaborators require owner approval. Only GitHub-owned, verified, and allowlisted third-party actions can run.
+- Every action is pinned to a full commit SHA and workflows are security-linted with zizmor on every PR. Secret scanning with push protection and Dependabot alerts are enabled.
 - Dependencies install through pnpm with a 7-day cooldown on new versions, and lifecycle scripts are blocked by default. CI installs with a frozen lockfile. Socket reviews every dependency change; Aikido scans every build.
 - npm releases are staged, never published directly: CI authenticates with **stage-only** OIDC trusted publishing (`npm stage publish` with provenance). Drydock reviews the staged artifact; a maintainer promotes with 2FA. The package requires 2FA and disallows tokens.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Record GitHub repository lockdown settings that are now live. Maintainer applied `lockdown-repo.sh` and then ran `--check`: **all applicable settings are in the desired state.** `SECURITY.md` only lists controls that are actually in place.

## Changes

- Check off § 2 script-applied items in `DEFENSE_IN_DEPTH.md` (PRs required, required checks, admin-only tags, fork-PR approval, read-only default token, Actions allowlist, secret scanning + push protection, Dependabot alerts).
- Drop the VM egress / PMG firewall checklist item — work is moving to isolated environments instead.
- Record phishing-resistant 2FA (passkeys / hardware keys) on the GitHub and npm accounts.
- Record recovery codes stored offline in a password manager.
- Update the public security summary with PRs-required, admin-only tags, fork-PR approval, and the Actions allowlist.

## Verification

- [x] Maintainer apply log: all 8 script steps succeeded (`You are admin: true`)
- [x] Maintainer `--check`: Audit: all applicable settings are in the desired state
- [x] Required checks: `tests (22)`, `tests (24)`, `tests (26)`, `zizmor`
- [x] Actions allowlist: GitHub-owned + verified + `zizmorcore/* pnpm/* codecov/* cloudflare/* dtolnay/* Swatinem/* taiki-e/*`
- [x] Maintainer confirmed phishing-resistant 2FA on GitHub and npm accounts
- [x] Maintainer confirmed recovery codes stored offline

## Still open

- Repo secret `AIKIDO_CLIENT_API_KEY` before the next GitHub Release
- Follow-up: `ai-integration-tests` also reports a check named `tests (24)`, so GitHub currently treats that job as required too. Rename that job after this PR so only the Node matrix owns `tests (24)`.

Reference: `defense-in-depth-nodejs § 2`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55303b82-7e77-4a66-9087-b8d64bcaffbd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55303b82-7e77-4a66-9087-b8d64bcaffbd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

