### PR TITLE
writr - chore: defense - uniquify AI integration check name

### DIFF
--- a/.github/workflows/ai-integration-tests.yml
+++ b/.github/workflows/ai-integration-tests.yml
@@ -11,13 +11,11 @@ permissions:
   contents: read
 
 jobs:
-  tests:
-
+  # Distinct check name from tests.yml's `tests (24)` so the branch ruleset
+  # required check does not also require this secrets-backed job.
+  ai-integration-tests:
+    name: ai-integration-tests
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: ['24']
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -25,10 +23,10 @@ jobs:
         persist-credentials: false
     - name: Install pnpm
       uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Use Node.js 24
       uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: 24
         cache: 'pnpm'
 
     - name: Install Dependencies

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -13,7 +13,7 @@ Profile: npm library · public
 
 - [x] Lockdown script run; `lockdown-repo.sh --check` passes clean — verified 2026-08-15 (maintainer `--check`)
 - [x] Pull requests required on the default branch; force pushes and deletion blocked — verified 2026-08-15 (ruleset "Pull requests required")
-- [x] Merges blocked unless required status checks pass (`--required-checks "<repo's CI jobs>"`) — verified 2026-08-15 (`tests (22)`, `tests (24)`, `tests (26)`, `zizmor`; AI integration reports `ai-integration-tests`) — PR # pending
+- [x] Merges blocked unless required status checks pass (`--required-checks "<repo's CI jobs>"`) — verified 2026-08-15 (`tests (22)`, `tests (24)`, `tests (26)`, `zizmor`; AI integration reports `ai-integration-tests`) — PR #513
 - [x] Tag ruleset "Tags only by admins" active — verified 2026-08-15
 - [x] Workflow runs from all outside collaborators require approval — verified 2026-08-15 (maintainer `--check`)
 - [x] Default workflow token read-only; Actions cannot create or approve PRs — verified 2026-08-15 (maintainer `--check`)

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -13,7 +13,7 @@ Profile: npm library · public
 
 - [x] Lockdown script run; `lockdown-repo.sh --check` passes clean — verified 2026-08-15 (maintainer `--check`)
 - [x] Pull requests required on the default branch; force pushes and deletion blocked — verified 2026-08-15 (ruleset "Pull requests required")
-- [x] Merges blocked unless required status checks pass (`--required-checks "<repo's CI jobs>"`) — verified 2026-08-15 (`tests (22)`, `tests (24)`, `tests (26)`, `zizmor`)
+- [x] Merges blocked unless required status checks pass (`--required-checks "<repo's CI jobs>"`) — verified 2026-08-15 (`tests (22)`, `tests (24)`, `tests (26)`, `zizmor`; AI integration reports `ai-integration-tests`) — PR # pending
 - [x] Tag ruleset "Tags only by admins" active — verified 2026-08-15
 - [x] Workflow runs from all outside collaborators require approval — verified 2026-08-15 (maintainer `--check`)
 - [x] Default workflow token read-only; Actions cannot create or approve PRs — verified 2026-08-15 (maintainer `--check`)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Give the AI integration workflow a distinct GitHub check name so the branch ruleset's required `tests (24)` check only refers to the Node test matrix.

## Status update

`DEFENSE_IN_DEPTH.md`: required checks remain `tests (22)`, `tests (24)`, `tests (26)`, `zizmor`; AI integration now reports `ai-integration-tests` — PR #513.

## Changes

- Rename the `ai-integration-tests` job (and drop the one-value Node matrix) so the check is `ai-integration-tests` instead of `tests (24)`.
- Note that distinction on the § 2 required-checks tracker line.

## Verification

- [x] `pnpm build` / `pnpm test`
- [x] CI: `tests (24)` comes only from the `tests` workflow (required)
- [x] CI: `ai-integration-tests` is a separate, non-required check

## Still open

- Repo secret `AIKIDO_CLIENT_API_KEY` before the next GitHub Release

Reference: `defense-in-depth-nodejs § 2`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55303b82-7e77-4a66-9087-b8d64bcaffbd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55303b82-7e77-4a66-9087-b8d64bcaffbd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

