### PR TITLE
fix: restore writr-rs goldens on Windows CRLF checkouts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Keep the tree LF-only. GitHub-hosted windows-latest runners default to
+# core.autocrlf=true, and actions/checkout v7 no longer overrides that, which
+# made the writr-rs golden harness diverge on CRLF markdown.
+* text=auto eol=lf

--- a/writr-rs/crates/writr-conformance/tests/reporting.rs
+++ b/writr-rs/crates/writr-conformance/tests/reporting.rs
@@ -110,6 +110,10 @@ fn check_reports_divergence_and_render_errors() {
 	std::fs::write(&golden, "<h1>Hello</h1>\n").unwrap();
 	assert!(check(&bad, &options).is_none());
 
+	// CRLF input (Windows checkout) must still match the LF golden.
+	std::fs::write(&input, "# Hello\r\n").unwrap();
+	assert!(check(&bad, &options).is_none());
+
 	// An input that fails to render (MDX syntax error) → render error path.
 	let mdx_input = dir.join("broken.mdx");
 	let mdx_golden = dir.join("broken.html");

--- a/writr-rs/crates/writr-core/src/pipeline.rs
+++ b/writr-rs/crates/writr-core/src/pipeline.rs
@@ -18,6 +18,7 @@ use crate::hast::{from_mdast, to_html};
 use crate::options::RenderOptions;
 use crate::{frontmatter, hast};
 use markdown::ParseOptions;
+use std::borrow::Cow;
 
 /// Check that every enabled runtime flag has its cargo feature compiled in.
 fn check_features(options: &RenderOptions) -> Result<(), RenderError> {
@@ -100,9 +101,21 @@ pub fn parse_to_mdast(
 	options: &RenderOptions,
 ) -> Result<markdown::mdast::Node, RenderError> {
 	check_features(options)?;
-	let body = frontmatter::body(input);
+	// Collapse CR/CRLF to LF before parsing. CommonMark treats all three as
+	// line endings, and micromark's sliceSerialize emits LF; markdown-rs
+	// copies CR into mdast text, which breaks GFM alerts, list continuations
+	// after a marker-only line, and highlight spans on Windows checkouts.
+	let normalized = unify_line_endings(input);
+	let body = frontmatter::body(&normalized);
 	markdown::to_mdast(body, &parse_options(options))
 		.map_err(|message| RenderError::Parse(message.to_string()))
+}
+
+fn unify_line_endings(input: &str) -> Cow<'_, str> {
+	if !input.as_bytes().contains(&b'\r') {
+		return Cow::Borrowed(input);
+	}
+	Cow::Owned(input.replace("\r\n", "\n").replace('\r', "\n"))
 }
 
 /// mdast transforms + conversion + hast transforms.

--- a/writr-rs/crates/writr-core/tests/api.rs
+++ b/writr-rs/crates/writr-core/tests/api.rs
@@ -176,6 +176,51 @@ fn render_batch_preserves_order_and_matches_render() {
 }
 
 #[test]
+fn crlf_and_cr_inputs_match_lf() {
+	// Windows checkouts (core.autocrlf=true) feed CRLF into the golden
+	// harness; markdown-rs would otherwise keep CR in mdast text.
+	let commonmark = RenderOptions::all_off();
+	let list_lf = "-\n  foo\n";
+	let list_html = render(list_lf, &commonmark).unwrap();
+	assert_eq!(list_html, "<ul>\n<li>foo</li>\n</ul>");
+	assert_eq!(
+		render(&list_lf.replace('\n', "\r\n"), &commonmark).unwrap(),
+		list_html
+	);
+	assert_eq!(render("-\r  foo\r", &commonmark).unwrap(), list_html);
+
+	let gfm = RenderOptions {
+		gfm: true,
+		..RenderOptions::all_off()
+	};
+	let alert_lf = "> [!CAUTION]\n> Negative potential consequences of an action.\n";
+	let alert_html = render(alert_lf, &gfm).unwrap();
+	assert!(
+		alert_html.contains("<p>Negative potential consequences of an action.</p>"),
+		"{alert_html}"
+	);
+	assert_eq!(
+		render(&alert_lf.replace('\n', "\r\n"), &gfm).unwrap(),
+		alert_html
+	);
+
+	let highlight = RenderOptions {
+		highlight: true,
+		..RenderOptions::all_off()
+	};
+	let fence_lf = "```js\n// fetch the stored flag from environment variables\n```\n";
+	let fence_html = render(fence_lf, &highlight).unwrap();
+	assert!(
+		fence_html.contains("hljs-comment") && fence_html.contains("</span>"),
+		"{fence_html}"
+	);
+	assert_eq!(
+		render(&fence_lf.replace('\n', "\r\n"), &highlight).unwrap(),
+		fence_html
+	);
+}
+
+#[test]
 fn katex_version_is_pinned() {
 	// The `math` feature is on by default; the constant carries the embedded
 	// KaTeX version for drift auditing.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix: Windows `native-matrix` golden harness.

The dummy-secrets change in #514 did not break the goldens. `native-matrix` only runs on `main` (PRs skip it), and Windows has been failing the same way since the GitHub Actions upgrade in #493.

`actions/checkout` v7 no longer sets `core.autocrlf=false`. GitHub-hosted `windows-latest` runners default to `core.autocrlf=true`, so the LF corpus is checked out as CRLF. markdown-rs copies CR into mdast text (micromark's `sliceSerialize` emits LF), which produced the CI diffs:

- `commonmark/0143` and `0341`: `<li>foo</li>` → `<li></li>`
- GFM alerts: `<p>…</p>` split so the body starts on the next line
- highlighted comments: `</span>` moved after a stray newline inside the span

**What is the current behavior?**

`native-matrix (windows-latest)` fails `writr-conformance` goldens (`commonmark`, `gfm-only`, `rawhtml`, `default`). Linux and macOS pass.

**What is the new behavior?**

- `parse_to_mdast` collapses CR/CRLF to LF before parsing (CommonMark line-ending unification; matches micromark).
- `.gitattributes` pins the tree to LF so Windows checkouts stop converting the corpus.
- Tests cover list items, GFM alerts, highlighted fences, and the harness `check()` path with CRLF input.

**Other information**:

Failed job: https://github.com/jaredwray/writr/actions/runs/31912144532/job/95078760756

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2bc4629-cbea-40aa-a989-3ecd16538a10?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2bc4629-cbea-40aa-a989-3ecd16538a10&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

