### PR TITLE
writr - chore: defense - add CODEOWNERS for high-risk paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# High-risk paths. Last matching pattern wins.
+# Root-anchored so nested copies (e.g. skills/**/scripts/) are not owned here.
+/.github/ @jaredwray
+/.cursor/ @jaredwray
+/.devcontainer/ @jaredwray
+/scripts/ @jaredwray

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -9,7 +9,7 @@ Profile: npm library · public
 - [x] `DEFENSE_IN_DEPTH.md` present (this file) — PR #506
 
 ## 2. CODEOWNERS and cloud bootstrap
-- [ ] `.github/CODEOWNERS` covers `/.github/`, `/.cursor/`, `/.devcontainer/`, `/scripts/` with owners the maintainer names (PR pending)
+- [ ] `.github/CODEOWNERS` covers `/.github/`, `/.cursor/`, `/.devcontainer/`, `/scripts/` with owners the maintainer names (PR #517 pending)
 - [ ] Codespaces and Cursor Cloud Agents bootstrap Aikido Safe Chain via scripts/setup-cloud-environment.sh (--ci shims, frozen lockfile)
 
 ## 3. Dependencies (pnpm)

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -5,54 +5,47 @@ Tracking against https://github.com/jaredwray/agentic/blob/main/skills/security/
 Profile: npm library · public
 
 ## 1. Security docs
-
 - [x] `SECURITY.md` present — contact info + "How this repository is secured" summary — PR #506
 - [x] `DEFENSE_IN_DEPTH.md` present (this file) — PR #506
 
-## 2. Repository lockdown
-
-- [x] Lockdown script run; `lockdown-repo.sh --check` passes clean — verified 2026-08-15 (maintainer `--check`)
-- [x] Pull requests required on the default branch; force pushes and deletion blocked — verified 2026-08-15 (ruleset "Pull requests required")
-- [x] Merges blocked unless required status checks pass (`--required-checks "<repo's CI jobs>"`) — verified 2026-08-15 (`tests (22)`, `tests (24)`, `tests (26)`, `zizmor`; AI integration reports `ai-integration-tests`) — PR #513
-- [x] Tag ruleset "Tags only by admins" active — verified 2026-08-15
-- [x] Workflow runs from all outside collaborators require approval — verified 2026-08-15 (maintainer `--check`)
-- [x] Default workflow token read-only; Actions cannot create or approve PRs — verified 2026-08-15 (maintainer `--check`)
-- [x] Actions allowlist: GitHub-owned + verified + explicit patterns only (`--allowed-actions`) — verified 2026-08-15 (`zizmorcore/* pnpm/* codecov/* cloudflare/* dtolnay/* Swatinem/* taiki-e/*`)
-- [x] Secret scanning + push protection enabled *(plan-gated on private repos)* — verified 2026-08-15 (maintainer `--check`)
-- [x] Private vulnerability reporting enabled *(public repos only)* — verified 2026-08-15
-- [x] Dependabot alerts enabled — verified 2026-08-15 (maintainer `--check`)
-- [x] Phishing-resistant 2FA (passkeys / hardware keys) on the GitHub and npm accounts (manual) — verified 2026-08-15 (maintainer)
-- [x] Recovery codes stored offline in a password manager (manual) — verified 2026-08-15 (maintainer)
+## 2. CODEOWNERS and cloud bootstrap
+- [ ] `.github/CODEOWNERS` covers `/.github/`, `/.cursor/`, `/.devcontainer/`, `/scripts/` with owners the maintainer names (PR pending)
+- [ ] Codespaces and Cursor Cloud Agents bootstrap Aikido Safe Chain via scripts/setup-cloud-environment.sh (--ci shims, frozen lockfile)
 
 ## 3. Dependencies (pnpm)
-
-- [x] `packageManager: pnpm@11.x` pinned in `package.json` — verified 2026-08-15 (`pnpm@11.21.0`)
-- [x] 7-day cooldown: `minimumReleaseAge: 10080`, `minimumReleaseAgeStrict: true`, `minimumReleaseAgeIgnoreMissingTime: false` — PR #506
-- [x] Lifecycle scripts blocked: `strictDepBuilds: true`, `dangerouslyAllowAllBuilds: false`, `allowBuilds: {}` baseline — PR #506 (default-deny; reviewed exceptions for `esbuild` and `unrs-resolver`)
+- [x] `packageManager: pnpm@11.3+` pinned in `package.json` — verified 2026-08-21 (`pnpm@11.21.0`)
+- [x] 7-day cooldown: `minimumReleaseAge: 10080`, `minimumReleaseAgeStrict: true`, `minimumReleaseAgeIgnoreMissingTime: false`; no first-party `minimumReleaseAgeExclude` — PR #506
+- [ ] `trustPolicy: no-downgrade`; no first-party `trustPolicyExclude`
+- [x] Lifecycle scripts blocked: `strictDepBuilds: true`, `dangerouslyAllowAllBuilds: false`, `allowBuilds: {}` baseline — PR #506 (reviewed exceptions for `esbuild` and `unrs-resolver`)
 - [x] `blockExoticSubdeps: true` — PR #506
 - [x] Lockfile committed; CI installs with `pnpm install --frozen-lockfile` — PR #506
-- [x] Dependency-update tooling opens PRs only — never auto-merge — verified 2026-08-15 (Dependabot Updates active; no auto-merge config in-repo)
-- [x] New direct dependencies get human review; prefer `~` ranges over `^` — PR #506
+- [x] No `.github/dependabot.yml`; other dependency-update tools (if any) open PRs only — never auto-merge — verified 2026-08-21
 
 ## 4. GitHub Actions
-
 - [x] `permissions: contents: read` (or `{}` + per-job grants) on every workflow — PR #506
-- [x] Every action pinned to a full commit SHA (`npx actions-up`) — verified 2026-08-15
+- [x] No `contents: write` except jobs whose purpose is mutating the repo (GitHub Release, Changesets version PR); generated output is a workflow artifact, never committed back from CI — verified 2026-08-21
+- [x] Every action pinned to a full commit SHA (`npx actions-up`) — verified 2026-08-21
+- [ ] Every job installs Socket Firewall (`SocketDev/action` SHA-pinned, `firewall-version` pinned); `pnpm install` / `npm install` run as `sfw pnpm install` / `sfw npm install`
 - [x] `.github/workflows/check-workflows.yaml` lints workflows with zizmor on every PR — PR #506
 - [x] `persist-credentials: false` on checkouts that don't push — PR #506
-- [x] No `pull_request_target` on workflows that run untrusted PR code — verified 2026-08-15
+- [x] No `pull_request_target` on workflows that run untrusted PR code — verified 2026-08-21
+- [x] Artifact-publishing workflows disable `actions/setup-node` default caching (`package-manager-cache: false`) to prevent cache poisoning — verified 2026-08-21 (`release.yml`)
 - [x] No npm tokens (or other registry credentials) in Actions secrets — verified 2026-08-15 (no workflow references `NPM_TOKEN` / `NODE_AUTH_TOKEN`; publish uses OIDC provenance)
 
 ## 5. npm publishing — npm libraries only
-
-- [x] OIDC trusted publishing configured **stage-only** on npmjs.com for the publish workflow — it can stage, never publish live — verified 2026-08-15 (maintainer)
-- [x] Staged publishing: CI runs `npm stage publish`; a maintainer promotes with 2FA — PR #507
-- [x] Drydock connected — staged releases reviewed before promotion — verified 2026-08-15 (maintainer)
-- [x] No direct publish rights: package requires 2FA and disallows tokens — verified 2026-08-15 (maintainer)
-- [x] `package.json` `repository.url` accurate so provenance maps to this repo — verified 2026-08-15
+- [x] OIDC trusted publishing configured **stage-only** on npmjs.com for the publish workflow — it can stage, never publish live (manual) — verified 2026-08-15 (maintainer)
+- [ ] `.github/workflows/release.yaml` packs then stages with `pnpm stage publish ./packed/*.tgz --no-git-checks`
+- [x] Maintainer promotes staged versions with 2FA (manual) — verified 2026-08-15 (maintainer)
+- [x] Drydock connected — staged releases reviewed before promotion (manual) — verified 2026-08-15 (maintainer)
+- [x] No direct publish rights: package requires 2FA and disallows tokens (manual) — verified 2026-08-15 (maintainer)
+- [x] `package.json` `repository.url` accurate so provenance maps to this repo — verified 2026-08-21
 
 ## 6. Security tooling
-
-- [x] Aikido runs on every build — verified 2026-08-15 (GitHub check "Aikido Security: check code" passed on PR #506)
+- [x] Aikido runs on every build — verified 2026-08-21 (GitHub check "Aikido Security: check code" passed on PR #516)
 - [x] Aikido release gate: the release workflow's stage-publish job `needs:` a passing `scan-release` — PR #506
-- [x] Socket reviews every PR that changes dependencies — verified 2026-08-15 (GitHub checks "Socket Security: Pull Request Alerts" and "Project Report" on PR #506)
+- [x] Socket reviews every PR that changes dependencies — verified 2026-08-21 (GitHub checks "Socket Security: Pull Request Alerts" and "Project Report" on PR #516)
+
+## 7. Repository lockdown
+- [ ] `lockdown-repo.sh` applied; `--check` with `--required-checks` and `--allowed-actions` passes (PRs required on the default branch, merges blocked unless required status checks pass, tag ruleset, immutable releases, fork-PR approval, read-only workflow tokens, Actions allowlist, secret scanning, Dependabot disabled, private vulnerability reporting as applicable)
+- [x] Phishing-resistant 2FA (passkeys / hardware keys) on the GitHub and npm accounts (manual) — verified 2026-08-15 (maintainer)
+- [x] Recovery codes stored offline in a password manager (manual) — verified 2026-08-15 (maintainer)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,6 +24,6 @@ This repository follows the [defense-in-depth](https://github.com/jaredwray/agen
 
 - All changes land through pull requests. Direct pushes to `main` are blocked; merging requires the `tests (22)`, `tests (24)`, `tests (26)`, and `zizmor` checks. Tags (releases) can only be created by repository admins.
 - CI runs with a read-only default workflow token; Actions cannot create or approve PRs. Workflow runs from outside collaborators require owner approval. Only GitHub-owned, verified, and allowlisted third-party actions can run.
-- Every action is pinned to a full commit SHA and workflows are security-linted with zizmor on every PR. Secret scanning with push protection and Dependabot alerts are enabled.
+- Every action is pinned to a full commit SHA and workflows are security-linted with zizmor on every PR. Secret scanning with push protection is enabled.
 - Dependencies install through pnpm with a 7-day cooldown on new versions, and lifecycle scripts are blocked by default. CI installs with a frozen lockfile. Socket reviews every dependency change; Aikido scans every build.
 - npm releases are staged, never published directly: CI authenticates with **stage-only** OIDC trusted publishing (`npm stage publish` with provenance). Drydock reviews the staged artifact; a maintainer promotes with 2FA. The package requires 2FA and disallows tokens.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Add `.github/CODEOWNERS` so `@jaredwray` owns high-risk paths (`defense-in-depth-nodejs` § 2).

## Status

`DEFENSE_IN_DEPTH.md`: CODEOWNERS → (PR #517 pending)

## Changes

- Add `.github/CODEOWNERS` covering `/.github/`, `/.cursor/`, `/.devcontainer/`, and `/scripts/`.
- Replace `DEFENSE_IN_DEPTH.md` with the current catalog and reconcile against repo state.
- Drop Dependabot alerts from the `SECURITY.md` summary (the current catalog treats Dependabot as disabled, not a control).

## Dropped catalog items

These old checkboxes are not in the current catalog and were not mapped:

- Dependabot alerts enabled
- New direct dependencies get human review; prefer `~` ranges
- Per-setting lockdown checkboxes (folded into one `lockdown-repo.sh --check` item)
- `npm stage publish` as the success criterion (replaced by `pnpm stage publish`)

## Verification

- [x] `pnpm build`
- [x] `pnpm test` (187 tests passed)

Reference: `defense-in-depth-nodejs` § 2
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a07787db-dad7-4300-b65c-1b61d28a0532?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a07787db-dad7-4300-b65c-1b61d28a0532&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

