### PR TITLE
writr - chore: defense - set pnpm trustPolicy no-downgrade

### DIFF
--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -15,7 +15,7 @@ Profile: npm library · public
 ## 3. Dependencies (pnpm)
 - [x] `packageManager: pnpm@11.3+` pinned in `package.json` — verified 2026-08-21 (`pnpm@11.21.0`)
 - [x] 7-day cooldown: `minimumReleaseAge: 10080`, `minimumReleaseAgeStrict: true`, `minimumReleaseAgeIgnoreMissingTime: false`; no first-party `minimumReleaseAgeExclude` — PR #506
-- [ ] `trustPolicy: no-downgrade`; no first-party `trustPolicyExclude` (PR pending)
+- [ ] `trustPolicy: no-downgrade`; no first-party `trustPolicyExclude` (PR #519 pending)
 - [x] Lifecycle scripts blocked: `strictDepBuilds: true`, `dangerouslyAllowAllBuilds: false`, `allowBuilds: {}` baseline — PR #506 (reviewed exceptions for `esbuild` and `unrs-resolver`)
 - [x] `blockExoticSubdeps: true` — PR #506
 - [x] Lockfile committed; CI installs with `pnpm install --frozen-lockfile` — PR #506

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -10,12 +10,12 @@ Profile: npm library · public
 
 ## 2. CODEOWNERS and cloud bootstrap
 - [x] `.github/CODEOWNERS` covers `/.github/`, `/.cursor/`, `/.devcontainer/`, `/scripts/` with owners the maintainer names — PR #517
-- [ ] Codespaces and Cursor Cloud Agents bootstrap Aikido Safe Chain via scripts/setup-cloud-environment.sh (--ci shims, frozen lockfile) (PR #518 pending)
+- [x] Codespaces and Cursor Cloud Agents bootstrap Aikido Safe Chain via scripts/setup-cloud-environment.sh (--ci shims, frozen lockfile) — PR #518
 
 ## 3. Dependencies (pnpm)
 - [x] `packageManager: pnpm@11.3+` pinned in `package.json` — verified 2026-08-21 (`pnpm@11.21.0`)
 - [x] 7-day cooldown: `minimumReleaseAge: 10080`, `minimumReleaseAgeStrict: true`, `minimumReleaseAgeIgnoreMissingTime: false`; no first-party `minimumReleaseAgeExclude` — PR #506
-- [ ] `trustPolicy: no-downgrade`; no first-party `trustPolicyExclude`
+- [ ] `trustPolicy: no-downgrade`; no first-party `trustPolicyExclude` (PR pending)
 - [x] Lifecycle scripts blocked: `strictDepBuilds: true`, `dangerouslyAllowAllBuilds: false`, `allowBuilds: {}` baseline — PR #506 (reviewed exceptions for `esbuild` and `unrs-resolver`)
 - [x] `blockExoticSubdeps: true` — PR #506
 - [x] Lockfile committed; CI installs with `pnpm install --frozen-lockfile` — PR #506

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,5 +26,5 @@ This repository follows the [defense-in-depth](https://github.com/jaredwray/agen
 - CI runs with a read-only default workflow token; Actions cannot create or approve PRs. Workflow runs from outside collaborators require owner approval. Only GitHub-owned, verified, and allowlisted third-party actions can run.
 - Every action is pinned to a full commit SHA and workflows are security-linted with zizmor on every PR. Secret scanning with push protection is enabled.
 - Codespaces and Cursor Cloud Agents install through Aikido Safe Chain; package-manager shims must not be bypassed.
-- Dependencies install through pnpm with a 7-day cooldown on new versions, and lifecycle scripts are blocked by default. CI installs with a frozen lockfile. Socket reviews every dependency change; Aikido scans every build.
+- Dependencies install through pnpm with a 7-day cooldown on new versions, lifecycle scripts blocked by default, and `trustPolicy: no-downgrade`. CI installs with a frozen lockfile. Socket reviews every dependency change; Aikido scans every build.
 - npm releases are staged, never published directly: CI authenticates with **stage-only** OIDC trusted publishing (`npm stage publish` with provenance). Drydock reviews the staged artifact; a maintainer promotes with 2FA. The package requires 2FA and disallows tokens.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   property-information: 7.1.0
   katex: 0.18.2
   '@ungap/structured-clone': 1.3.3
+  undici@5: 7.29.0
 
 importers:
 
@@ -450,10 +451,6 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
-
-  '@fastify/busboy@2.1.1':
-    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
-    engines: {node: '>=14'}
 
   '@jaredwray/fumanchu@4.7.2':
     resolution: {integrity: sha512-LTiNhIH6RvsiUBN13osqXgezY/JNNMHydlx6mMLPJQq4mox6C+Y5NXV1YZwRq+25S6tVlTCcDOPUY24iVwefmg==}
@@ -2363,10 +2360,6 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
-  undici@5.29.0:
-    resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
-    engines: {node: '>=14.0'}
-
   undici@7.29.0:
     resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
@@ -2617,7 +2610,7 @@ snapshots:
       '@ai-sdk/provider': 3.0.14
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.1.0
-      undici: 5.29.0
+      undici: 7.29.0
       zod: 4.4.3
 
   '@ai-sdk/provider-utils@5.0.25(zod@4.4.3)':
@@ -2784,8 +2777,6 @@ snapshots:
 
   '@esbuild/win32-x64@0.28.1':
     optional: true
-
-  '@fastify/busboy@2.1.1': {}
 
   '@jaredwray/fumanchu@4.7.2':
     dependencies:
@@ -4932,10 +4923,6 @@ snapshots:
       quansync: 1.0.0
 
   undici-types@7.18.2: {}
-
-  undici@5.29.0:
-    dependencies:
-      '@fastify/busboy': 2.1.1
 
   undici@7.29.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,7 @@ minimumReleaseAgeIgnoreMissingTime: false # missing publish-time metadata fails 
 blockExoticSubdeps: true
 strictDepBuilds: true
 dangerouslyAllowAllBuilds: false
+trustPolicy: no-downgrade # fail if a later version has weaker trust evidence
 
 # Force a single property-information so JS serialization and Rust codegen
 # tables stay on the same audited version (7.1.0).
@@ -11,10 +12,14 @@ dangerouslyAllowAllBuilds: false
 # ^0.16.0, which never reaches 0.18.2; keep the Rust vendor in lockstep.
 # Pin @ungap/structured-clone to the AIKIDO-2026-11068 patch. Parents declare
 # ^1.0.0, which still admits 1.3.0.
+# Pin undici@5 to 7.29.0: 5.29.0 has no trusted publisher and fails
+# trustPolicy: no-downgrade (possible package takeover). 7.29.0 is already
+# in the tree via the current AI SDK and was published with OIDC.
 overrides:
   property-information: 7.1.0
   katex: 0.18.2
   "@ungap/structured-clone": 1.3.3
+  undici@5: 7.29.0
 
 # Lifecycle-script exceptions — each entry is a reviewed security exception.
 # esbuild: used by tsdown / the JS build.

--- a/writr-rs/crates/writr-node/pnpm-workspace.yaml
+++ b/writr-rs/crates/writr-node/pnpm-workspace.yaml
@@ -4,6 +4,7 @@ minimumReleaseAgeIgnoreMissingTime: false
 blockExoticSubdeps: true
 strictDepBuilds: true
 dangerouslyAllowAllBuilds: false
+trustPolicy: no-downgrade # fail if a later version has weaker trust evidence
 
 # esbuild: wasm/browser bundling for the Node binding.
 allowBuilds:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Enable pnpm `trustPolicy: no-downgrade` so installs fail if a later package version has weaker trust evidence (`defense-in-depth-nodejs` § 3).

## Status

`DEFENSE_IN_DEPTH.md`: trustPolicy → (PR #519 pending)

## Changes

- Set `trustPolicy: no-downgrade` in the root and `writr-rs/crates/writr-node` workspace files. No `trustPolicyExclude`.
- Override `undici@5` to `7.29.0`. `undici@5.29.0` has no trusted publisher and fails the gate; `7.29.0` is already in the tree via the current AI SDK and was published with OIDC.
- Check off Safe Chain (PR #518) and add `trustPolicy: no-downgrade` to the `SECURITY.md` summary (completes § 3).

## Verification

- [x] `pnpm install --frozen-lockfile` (root) passes supply-chain policy check
- [x] `pnpm install --frozen-lockfile` in `writr-rs/crates/writr-node`
- [x] `pnpm build`
- [x] `pnpm test` (187 tests passed)

Reference: `defense-in-depth-nodejs` § 3

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a07787db-dad7-4300-b65c-1b61d28a0532?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a07787db-dad7-4300-b65c-1b61d28a0532&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

