### PR TITLE
writr - chore: defense - add Socket Firewall to every job

### DIFF
--- a/.github/workflows/ai-integration-tests.yml
+++ b/.github/workflows/ai-integration-tests.yml
@@ -21,6 +21,11 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
+    - name: Install Socket Firewall
+      uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      with:
+        mode: firewall-free
+        firewall-version: "1.15.0"
     - name: Install pnpm
       uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
     - name: Use Node.js 24
@@ -30,7 +35,7 @@ jobs:
         cache: 'pnpm'
 
     - name: Install Dependencies
-      run: pnpm install --frozen-lockfile
+      run: sfw pnpm install --frozen-lockfile
 
     - name: Build
       run: pnpm build

--- a/.github/workflows/check-workflows.yaml
+++ b/.github/workflows/check-workflows.yaml
@@ -19,5 +19,10 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      - name: Install Socket Firewall
+        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+          firewall-version: "1.15.0"
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -19,6 +19,11 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
+    - name: Install Socket Firewall
+      uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      with:
+        mode: firewall-free
+        firewall-version: "1.15.0"
     - name: Install pnpm
       uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
     - name: Use Node.js
@@ -28,7 +33,7 @@ jobs:
         cache: 'pnpm'
 
     - name: Install Dependencies
-      run: pnpm install --frozen-lockfile
+      run: sfw pnpm install --frozen-lockfile
 
     - name: Build    
       run: pnpm build

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -63,6 +63,12 @@ jobs:
       with:
         persist-credentials: false
 
+    - name: Install Socket Firewall
+      uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      with:
+        mode: firewall-free
+        firewall-version: "1.15.0"
+
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`
     # or others). This is typically only required for manual builds.

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -19,6 +19,12 @@ jobs:
       with:
         persist-credentials: false
 
+    - name: Install Socket Firewall
+      uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      with:
+        mode: firewall-free
+        firewall-version: "1.15.0"
+
     # Test
     - name: Install pnpm
       uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
@@ -30,7 +36,7 @@ jobs:
         cache: 'pnpm'
 
     - name: Install Dependencies
-      run: pnpm install --frozen-lockfile
+      run: sfw pnpm install --frozen-lockfile
       
     - name: Build
       run: pnpm build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,15 @@ jobs:
   aikido-gate:
     name: Aikido release gate
     runs-on: ubuntu-latest
-    permissions: {}
+    permissions:
+      contents: read
     steps:
+      - name: Install Socket Firewall
+        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+          firewall-version: "1.15.0"
+
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -22,7 +29,7 @@ jobs:
 
       - name: Install Aikido CI client
         # zizmor: ignore[adhoc-packages] pinned Aikido CI client for the release gate
-        run: npm install --global @aikidosec/ci-api-client@1.0.17
+        run: sfw npm install --global @aikidosec/ci-api-client@1.0.17
 
       # Fails on new SAST/IaC/secrets findings. The API key comes from Aikido's
       # Continuous Integration settings — it grants no publish authority.
@@ -47,6 +54,11 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
+    - name: Install Socket Firewall
+      uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      with:
+        mode: firewall-free
+        firewall-version: "1.15.0"
     - name: Install pnpm
       uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
     - name: Use Node.js
@@ -57,7 +69,7 @@ jobs:
         package-manager-cache: false
 
     - name: Install Dependencies
-      run: pnpm install --frozen-lockfile
+      run: sfw pnpm install --frozen-lockfile
 
     - name: Build
       run: pnpm build
@@ -73,7 +85,7 @@ jobs:
 
     - name: Ensure npm CLI for staged publishing
       # zizmor: ignore[adhoc-packages] pin npm 11.19.0 so `npm stage publish` is available
-      run: npm install --global npm@11.19.0
+      run: sfw npm install --global npm@11.19.0
 
     - name: Stage publish
       run: npm stage publish packed/*.tgz --access public --provenance

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,11 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
+    - name: Install Socket Firewall
+      uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      with:
+        mode: firewall-free
+        firewall-version: "1.15.0"
     - name: Install pnpm
       uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
     - name: Use Node.js ${{ matrix.node-version }}
@@ -32,7 +37,7 @@ jobs:
         cache: 'pnpm'
 
     - name: Install Dependencies
-      run: pnpm install --frozen-lockfile
+      run: sfw pnpm install --frozen-lockfile
 
     - name: Build
       run: pnpm build

--- a/.github/workflows/writr-rs.yml
+++ b/.github/workflows/writr-rs.yml
@@ -32,6 +32,11 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      - name: Install Socket Firewall
+        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+          firewall-version: "1.15.0"
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: '1.94.1'
@@ -71,13 +76,18 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      - name: Install Socket Firewall
+        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+          firewall-version: "1.15.0"
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22'
           cache: 'pnpm'
       - name: Install Dependencies
-        run: pnpm install --frozen-lockfile
+        run: sfw pnpm install --frozen-lockfile
       - name: Regenerate committed codegen outputs
         run: node writr-rs/tools/gen-all.mjs
       - name: Verify no drift
@@ -89,6 +99,11 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      - name: Install Socket Firewall
+        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+          firewall-version: "1.15.0"
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -104,11 +119,11 @@ jobs:
       - name: Install wasi sysroot (QuickJS C sources) + binaryen
         run: sudo apt-get update && sudo apt-get install -y wasi-libc libclang-rt-18-dev-wasm32 llvm binaryen
       - name: Install Dependencies
-        run: pnpm install --frozen-lockfile
+        run: sfw pnpm install --frozen-lockfile
       # crates/writr-node has its own pnpm-workspace.yaml (settings boundary
       # + esbuild allowBuilds), so a plain install stays local to it.
       - name: Install binding dependencies
-        run: pnpm install --frozen-lockfile
+        run: sfw pnpm install --frozen-lockfile
         working-directory: writr-rs/crates/writr-node
       - name: Build native addon
         run: pnpm build:rs
@@ -151,6 +166,11 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      - name: Install Socket Firewall
+        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+          firewall-version: "1.15.0"
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: '1.94.1'

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -15,7 +15,7 @@ Profile: npm library · public
 ## 3. Dependencies (pnpm)
 - [x] `packageManager: pnpm@11.3+` pinned in `package.json` — verified 2026-08-21 (`pnpm@11.21.0`)
 - [x] 7-day cooldown: `minimumReleaseAge: 10080`, `minimumReleaseAgeStrict: true`, `minimumReleaseAgeIgnoreMissingTime: false`; no first-party `minimumReleaseAgeExclude` — PR #506
-- [ ] `trustPolicy: no-downgrade`; no first-party `trustPolicyExclude` (PR #519 pending)
+- [x] `trustPolicy: no-downgrade`; no first-party `trustPolicyExclude` — PR #519
 - [x] Lifecycle scripts blocked: `strictDepBuilds: true`, `dangerouslyAllowAllBuilds: false`, `allowBuilds: {}` baseline — PR #506 (reviewed exceptions for `esbuild` and `unrs-resolver`)
 - [x] `blockExoticSubdeps: true` — PR #506
 - [x] Lockfile committed; CI installs with `pnpm install --frozen-lockfile` — PR #506
@@ -25,7 +25,7 @@ Profile: npm library · public
 - [x] `permissions: contents: read` (or `{}` + per-job grants) on every workflow — PR #506
 - [x] No `contents: write` except jobs whose purpose is mutating the repo (GitHub Release, Changesets version PR); generated output is a workflow artifact, never committed back from CI — verified 2026-08-21
 - [x] Every action pinned to a full commit SHA (`npx actions-up`) — verified 2026-08-21
-- [ ] Every job installs Socket Firewall (`SocketDev/action` SHA-pinned, `firewall-version` pinned); `pnpm install` / `npm install` run as `sfw pnpm install` / `sfw npm install`
+- [ ] Every job installs Socket Firewall (`SocketDev/action` SHA-pinned, `firewall-version` pinned); `pnpm install` / `npm install` run as `sfw pnpm install` / `sfw npm install` (PR pending)
 - [x] `.github/workflows/check-workflows.yaml` lints workflows with zizmor on every PR — PR #506
 - [x] `persist-credentials: false` on checkouts that don't push — PR #506
 - [x] No `pull_request_target` on workflows that run untrusted PR code — verified 2026-08-21

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -25,7 +25,7 @@ Profile: npm library · public
 - [x] `permissions: contents: read` (or `{}` + per-job grants) on every workflow — PR #506
 - [x] No `contents: write` except jobs whose purpose is mutating the repo (GitHub Release, Changesets version PR); generated output is a workflow artifact, never committed back from CI — verified 2026-08-21
 - [x] Every action pinned to a full commit SHA (`npx actions-up`) — verified 2026-08-21
-- [ ] Every job installs Socket Firewall (`SocketDev/action` SHA-pinned, `firewall-version` pinned); `pnpm install` / `npm install` run as `sfw pnpm install` / `sfw npm install` (PR pending)
+- [ ] Every job installs Socket Firewall (`SocketDev/action` SHA-pinned, `firewall-version` pinned); `pnpm install` / `npm install` run as `sfw pnpm install` / `sfw npm install` (PR #520 pending)
 - [x] `.github/workflows/check-workflows.yaml` lints workflows with zizmor on every PR — PR #506
 - [x] `persist-credentials: false` on checkouts that don't push — PR #506
 - [x] No `pull_request_target` on workflows that run untrusted PR code — verified 2026-08-21

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,7 +24,7 @@ This repository follows the [defense-in-depth](https://github.com/jaredwray/agen
 
 - All changes land through pull requests. Direct pushes to `main` are blocked; merging requires the `tests (22)`, `tests (24)`, `tests (26)`, and `zizmor` checks. Tags (releases) can only be created by repository admins.
 - CI runs with a read-only default workflow token; Actions cannot create or approve PRs. Workflow runs from outside collaborators require owner approval. Only GitHub-owned, verified, and allowlisted third-party actions can run.
-- Every action is pinned to a full commit SHA and workflows are security-linted with zizmor on every PR. Secret scanning with push protection is enabled.
+- Every action is pinned to a full commit SHA; Socket Firewall (`sfw`) wraps `pnpm install` / `npm install`; workflows are security-linted with zizmor on every PR. Secret scanning with push protection is enabled.
 - Codespaces and Cursor Cloud Agents install through Aikido Safe Chain; package-manager shims must not be bypassed.
 - Dependencies install through pnpm with a 7-day cooldown on new versions, lifecycle scripts blocked by default, and `trustPolicy: no-downgrade`. CI installs with a frozen lockfile. Socket reviews every dependency change; Aikido scans every build.
 - npm releases are staged, never published directly: CI authenticates with **stage-only** OIDC trusted publishing (`npm stage publish` with provenance). Drydock reviews the staged artifact; a maintainer promotes with 2FA. The package requires 2FA and disallows tokens.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Install Socket Firewall Free on every GitHub Actions job and wrap `pnpm install` / `npm install` with `sfw` (`defense-in-depth-nodejs` § 4).

## Status

`DEFENSE_IN_DEPTH.md`: Socket Firewall → (PR #520 pending)

## Changes

- Add SHA-pinned `SocketDev/action@v1.3.2` (`firewall-version: 1.15.0`) after checkout on every job (first step on the Aikido gate, which does not check out).
- Prefix every `pnpm install` and `npm install` with `sfw`.
- Grant the Aikido gate `contents: read` so the action can fetch the release.
- Check off trustPolicy (PR #519) and record `sfw` in the `SECURITY.md` summary (completes § 4).

## Verification

- [x] `npx actions-up --dry-run` — SocketDev/action is already at v1.3.2; no other pins applied
- [x] `pnpm build`
- [x] `pnpm test` (187 tests passed)

Reference: `defense-in-depth-nodejs` § 4

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a07787db-dad7-4300-b65c-1b61d28a0532?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a07787db-dad7-4300-b65c-1b61d28a0532&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

