### PR TITLE
writr - chore: defense - record repository lockdown

### DIFF
--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -34,7 +34,7 @@ Profile: npm library · public
 
 ## 5. npm publishing — npm libraries only
 - [x] OIDC trusted publishing configured **stage-only** on npmjs.com for the publish workflow — it can stage, never publish live (manual) — verified 2026-08-15 (maintainer)
-- [ ] `.github/workflows/release.yaml` packs then stages with `pnpm stage publish ./packed/*.tgz --no-git-checks` (PR #521 pending)
+- [x] `.github/workflows/release.yaml` packs then stages with `pnpm stage publish ./packed/*.tgz --no-git-checks` — PR #521
 - [x] Maintainer promotes staged versions with 2FA (manual) — verified 2026-08-15 (maintainer)
 - [x] Drydock connected — staged releases reviewed before promotion (manual) — verified 2026-08-15 (maintainer)
 - [x] No direct publish rights: package requires 2FA and disallows tokens (manual) — verified 2026-08-15 (maintainer)
@@ -46,6 +46,6 @@ Profile: npm library · public
 - [x] Socket reviews every PR that changes dependencies — verified 2026-08-21 (GitHub checks "Socket Security: Pull Request Alerts" and "Project Report" on PR #516)
 
 ## 7. Repository lockdown
-- [ ] `lockdown-repo.sh` applied; `--check` with `--required-checks` and `--allowed-actions` passes (PRs required on the default branch, merges blocked unless required status checks pass, tag ruleset, immutable releases, fork-PR approval, read-only workflow tokens, Actions allowlist, secret scanning, Dependabot disabled, private vulnerability reporting as applicable)
+- [ ] `lockdown-repo.sh` applied; `--check` with `--required-checks` and `--allowed-actions` passes (PRs required on the default branch, merges blocked unless required status checks pass, tag ruleset, immutable releases, fork-PR approval, read-only workflow tokens, Actions allowlist, secret scanning, Dependabot disabled, private vulnerability reporting as applicable) (PR pending)
 - [x] Phishing-resistant 2FA (passkeys / hardware keys) on the GitHub and npm accounts (manual) — verified 2026-08-15 (maintainer)
 - [x] Recovery codes stored offline in a password manager (manual) — verified 2026-08-15 (maintainer)

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -46,6 +46,6 @@ Profile: npm library · public
 - [x] Socket reviews every PR that changes dependencies — verified 2026-08-21 (GitHub checks "Socket Security: Pull Request Alerts" and "Project Report" on PR #516)
 
 ## 7. Repository lockdown
-- [ ] `lockdown-repo.sh` applied; `--check` with `--required-checks` and `--allowed-actions` passes (PRs required on the default branch, merges blocked unless required status checks pass, tag ruleset, immutable releases, fork-PR approval, read-only workflow tokens, Actions allowlist, secret scanning, Dependabot disabled, private vulnerability reporting as applicable) (PR pending)
+- [ ] `lockdown-repo.sh` applied; `--check` with `--required-checks` and `--allowed-actions` passes (PRs required on the default branch, merges blocked unless required status checks pass, tag ruleset, immutable releases, fork-PR approval, read-only workflow tokens, Actions allowlist, secret scanning, Dependabot disabled, private vulnerability reporting as applicable) (PR #522 pending)
 - [x] Phishing-resistant 2FA (passkeys / hardware keys) on the GitHub and npm accounts (manual) — verified 2026-08-15 (maintainer)
 - [x] Recovery codes stored offline in a password manager (manual) — verified 2026-08-15 (maintainer)

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -46,6 +46,6 @@ Profile: npm library · public
 - [x] Socket reviews every PR that changes dependencies — verified 2026-08-21 (GitHub checks "Socket Security: Pull Request Alerts" and "Project Report" on PR #516)
 
 ## 7. Repository lockdown
-- [ ] `lockdown-repo.sh` applied; `--check` with `--required-checks` and `--allowed-actions` passes (PRs required on the default branch, merges blocked unless required status checks pass, tag ruleset, immutable releases, fork-PR approval, read-only workflow tokens, Actions allowlist, secret scanning, Dependabot disabled, private vulnerability reporting as applicable) (PR #522 pending)
+- [x] `lockdown-repo.sh` applied; `--check` with `--required-checks` and `--allowed-actions` passes (PRs required on the default branch, merges blocked unless required status checks pass, tag ruleset, immutable releases, fork-PR approval, read-only workflow tokens, Actions allowlist, secret scanning, Dependabot disabled, private vulnerability reporting as applicable) — verified 2026-08-22 (maintainer `--check`)
 - [x] Phishing-resistant 2FA (passkeys / hardware keys) on the GitHub and npm accounts (manual) — verified 2026-08-15 (maintainer)
 - [x] Recovery codes stored offline in a password manager (manual) — verified 2026-08-15 (maintainer)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,7 +22,7 @@ We will acknowledge receipt, work with you on a coordinated disclosure timeline,
 
 This repository follows the [defense-in-depth](https://github.com/jaredwray/agentic/blob/main/skills/security/defense-in-depth-nodejs/SKILL.md) hardening checklist; progress is tracked in [DEFENSE_IN_DEPTH.md](./DEFENSE_IN_DEPTH.md). Measures currently in place:
 
-- All changes land through pull requests. Direct pushes to `main` are blocked; merging requires the `tests (22)`, `tests (24)`, `tests (26)`, and `zizmor` checks. Tags (releases) can only be created by repository admins.
+- All changes land through pull requests. Direct pushes to `main` are blocked; merging requires the `tests (22)`, `tests (24)`, `tests (26)`, and `zizmor` checks. Tags can only be created by repository admins; published GitHub Releases are immutable.
 - CI runs with a read-only default workflow token; Actions cannot create or approve PRs. Workflow runs from outside collaborators require owner approval. Only GitHub-owned, verified, and allowlisted third-party actions can run.
 - Every action is pinned to a full commit SHA; Socket Firewall (`sfw`) wraps `pnpm install` / `npm install`; workflows are security-linted with zizmor on every PR. Secret scanning with push protection is enabled.
 - Codespaces and Cursor Cloud Agents install through Aikido Safe Chain; package-manager shims must not be bypassed.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Record that `lockdown-repo.sh --check` now passes on `jaredwray/writr` (`defense-in-depth-nodejs` § 7).

## Status

`DEFENSE_IN_DEPTH.md`: lockdown → (PR #522 pending)

## Changes

- Check off the lockdown item after a clean maintainer `--check` (admin: true; all 9 settings in the desired state).
- Check off pnpm stage publish (PR #521).
- Note immutable GitHub Releases in the `SECURITY.md` summary.

## Verification

- [x] Maintainer `--check`: Audit: all applicable settings are in the desired state
- [x] Required checks: `tests (22)`, `tests (24)`, `tests (26)`, `zizmor`
- [x] Actions allowlist: `zizmorcore/* SocketDev/* pnpm/* codecov/* cloudflare/* dtolnay/* Swatinem/* taiki-e/*`
- [x] `pnpm build`
- [x] `pnpm test` (187 tests passed)

Reference: `defense-in-depth-nodejs` § 7

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a07787db-dad7-4300-b65c-1b61d28a0532?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a07787db-dad7-4300-b65c-1b61d28a0532&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

