### PR TITLE
ci: pin taiki-e/install-action to an authentic v2.86.5 SHA

### DIFF
--- a/.github/workflows/writr-rs.yml
+++ b/.github/workflows/writr-rs.yml
@@ -61,7 +61,7 @@ jobs:
           done
         working-directory: writr-rs
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@b549cefc011fbb8c6ea6125469ebafdb8f24bd7d # cargo-llvm-cov
+        uses: taiki-e/install-action@ba47c86ac325773530516bb756137ac718732518 # v2.86.5
         with:
           tool: cargo-llvm-cov
       # 97.75% at gate introduction; every uncovered line is documented as


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [ ] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix (CI / supply-chain lint).

## Summary

zizmor failed on `.github/workflows/writr-rs.yml:64` with two findings against the same pin:

1. **Error `impostor-commit`**: `commit with no history in referenced repository` — the SHA was the floating `@cargo-llvm-cov` tool tag (`b549cef…`), an orphan commit, not a commit on `taiki-e/install-action`.
2. **Warning `ref-version-mismatch`**: `action's hash pin has mismatched or missing version comment: points to commit d88826bbe7e4` — the comment `# cargo-llvm-cov` is a moving tool tag, now at `d88826b…`, not the pinned SHA.

`taiki-e/install-action` documents that pinning `@<tool_name>` tags by hash is unsafe for exactly this reason.

This PR pins the action to the real **v2.86.5** release commit (`ba47c86ac325773530516bb756137ac718732518`), which is identical to `main` on that repo, and comments `# v2.86.5`. `tool: cargo-llvm-cov` is unchanged.

## Verification

- [x] Workflow YAML still parses
- [x] `ba47c86…` is the `v2.86.5` tag and is identical to `taiki-e/install-action` `main`
- [x] Local zizmor 1.29.0: old pin reports both findings; new pin has no findings under the regular persona
- [x] GitHub `zizmor` check passed
- [x] `rust-checks` passed, including Install cargo-llvm-cov and the coverage gate
- [x] All 19 CI checks on this PR completed without failures

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c5ae285f-5247-4e70-80f1-babe0a217baa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c5ae285f-5247-4e70-80f1-babe0a217baa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

