### PR TITLE
ci: disable setup-node cache in deploy-site to prevent cache poisoning

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -33,7 +33,7 @@ jobs:
       uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: 24
-        cache: 'pnpm'
+        package-manager-cache: false
 
     - name: Install Dependencies
       run: sfw pnpm install --frozen-lockfile

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -29,7 +29,7 @@ Profile: npm library · public
 - [x] `.github/workflows/check-workflows.yaml` lints workflows with zizmor on every PR — PR #506
 - [x] `persist-credentials: false` on checkouts that don't push — PR #506
 - [x] No `pull_request_target` on workflows that run untrusted PR code — verified 2026-08-21
-- [x] Artifact-publishing workflows disable `actions/setup-node` default caching (`package-manager-cache: false`) to prevent cache poisoning — verified 2026-08-21 (`release.yml`)
+- [x] Artifact-publishing workflows disable `actions/setup-node` default caching (`package-manager-cache: false`) to prevent cache poisoning — verified 2026-08-22 (`release.yml`, `deploy-site.yml`)
 - [x] No npm tokens (or other registry credentials) in Actions secrets — verified 2026-08-15 (no workflow references `NPM_TOKEN` / `NODE_AUTH_TOKEN`; publish uses OIDC provenance)
 
 ## 5. npm publishing — npm libraries only


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [ ] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, ...)

Bug fix for a zizmor `cache-poisoning` finding on the website deploy workflow.

## Summary
`deploy-site.yml` publishes to Cloudflare Pages on `release` events. zizmor flags `actions/setup-node` with `cache: 'pnpm'` in that publishing workflow because a poisoned GitHub Actions cache from an earlier run could be restored into the job that builds and deploys the site.

This matches the existing hardening in `release.yml`: drop the pnpm cache opt-in and set `package-manager-cache: false` so setup-node neither restores nor saves a package-manager cache.

CI test/coverage workflows keep their pnpm cache; those jobs do not publish artifacts.

## Test plan
- [x] Run zizmor 1.29.0 locally against `origin/main` `deploy-site.yml` — high `cache-poisoning` finding on `setup-node` `cache: 'pnpm'`.
- [x] Run zizmor 1.29.0 locally against this change — `deploy-site.yml` reports no findings.
- [x] Run zizmor 1.29.0 against all `.github/workflows` — no findings (30 suppressed, same as before this change aside from the deploy-site finding).
- [x] GitHub CI on this branch: all 15 checks passed, including zizmor.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4153c067-903f-4cf6-bbd3-cd66be2a2e00?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4153c067-903f-4cf6-bbd3-cd66be2a2e00&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

